### PR TITLE
Fix centered scene parallax position

### DIFF
--- a/src/WPShaderValueUpdater.cpp
+++ b/src/WPShaderValueUpdater.cpp
@@ -202,9 +202,10 @@ void WPShaderValueUpdater::UpdateUniforms(SceneNode* pNode, sprite_map_t& sprite
                      m_screen_size[0], m_screen_size[1], m_screen_size[0] / m_screen_size[1] });
 
     if (info.has_PARALLAXPOSITION) {
+        const Vector2f mouseCentered = Vector2f(&m_mousePos[0]) - Vector2f { 0.5f, 0.5f };
         Vector2f para =
             Vector2f { 0.5f, 0.5f } +
-            (Scaling(1.0f, -1.0f) * (Vector2f(&m_mousePos[0])) - Vector2f { 0.5f, 0.5f }) *
+            (Scaling(1.0f, -1.0f) * mouseCentered) *
                 m_parallax.mouseinfluence;
         updateOp(G_PARALLAXPOSITION, std::array { para[0], para[1] });
     }

--- a/src/WPShaderValueUpdater.cpp
+++ b/src/WPShaderValueUpdater.cpp
@@ -202,11 +202,12 @@ void WPShaderValueUpdater::UpdateUniforms(SceneNode* pNode, sprite_map_t& sprite
                      m_screen_size[0], m_screen_size[1], m_screen_size[0] / m_screen_size[1] });
 
     if (info.has_PARALLAXPOSITION) {
-        const Vector2f mouseCentered = Vector2f(&m_mousePos[0]) - Vector2f { 0.5f, 0.5f };
-        Vector2f para =
-            Vector2f { 0.5f, 0.5f } +
-            (Scaling(1.0f, -1.0f) * mouseCentered) *
-                m_parallax.mouseinfluence;
+        Vector2f para { 0.5f, 0.5f };
+        if (m_parallax.enable) {
+            const Vector2f mouseCentered = Vector2f(&m_mousePos[0]) - Vector2f { 0.5f, 0.5f };
+            para = Vector2f { 0.5f, 0.5f } +
+                   (Scaling(1.0f, -1.0f) * mouseCentered) * m_parallax.mouseinfluence;
+        }        m_parallax.mouseinfluence;
         updateOp(G_PARALLAXPOSITION, std::array { para[0], para[1] });
     }
 


### PR DESCRIPTION
## Summary

This fixes the centered `g_ParallaxPosition` calculation in `WPShaderValueUpdater`.

With the previous formula, a centered cursor position `(0.5, 0.5)` did not map back to a centered parallax position. Shaders using `g_ParallaxPosition` could therefore show an unintended offset even when the pointer was exactly in the middle of the screen.

## Problem

The old code applied the Y-flip before converting the mouse position into a center-relative vector:

```cpp
(Scaling(1.0f, -1.0f) * (Vector2f(&m_mousePos[0])) - Vector2f { 0.5f, 0.5f })
```
That makes the midpoint behave incorrectly. The neutral cursor position should produce a neutral parallax position, but it does not.

## Fix

Center the mouse position first, then apply the Y-flip:

```cpp
const Vector2f mouseCentered = Vector2f(&m_mousePos[0]) - Vector2f { 0.5f, 0.5f };
Vector2f para =
    Vector2f { 0.5f, 0.5f } +
    (Scaling(1.0f, -1.0f) * mouseCentered) *
        m_parallax.mouseinfluence;
```

This preserves the expected Y inversion while keeping the center stable.

## Result

- Pointer at `(0.5, 0.5)` now produces `g_ParallaxPosition == (0.5, 0.5)`
- Parallax remains responsive away from center
- Existing Y-axis flip behavior is preserved

## Testing
Tested with a scene wallpaper that uses parallax-position-driven shader behavior.

- Related wallpaper: `2809353050`

before
<img width="3199" height="1999" alt="屏幕截图_20260408_133855" src="https://github.com/user-attachments/assets/e6cef1f0-074d-4c18-844b-c1e19d28c022" />

after
<img width="3199" height="1999" alt="屏幕截图_20260408_143511" src="https://github.com/user-attachments/assets/302fa897-f845-43cf-b8e3-0d03eee339c6" />
