### PR TITLE
Fix orthographic eye position for trail particles

### DIFF
--- a/src/WPSceneParser.cpp
+++ b/src/WPSceneParser.cpp
@@ -964,6 +964,13 @@ void ParseParticleObj(ParseContext& context, wpscene::WPParticleObject& wppartob
     shaderInfo.baseConstSvs["g_OrientationForward"] = std::array { 0.0f, 0.0f, 1.0f };
     shaderInfo.baseConstSvs["g_ViewUp"]             = std::array { 0.0f, 1.0f, 0.0f };
     shaderInfo.baseConstSvs["g_ViewRight"]          = std::array { 1.0f, 0.0f, 0.0f };
+	shaderInfo.baseConstSvs["g_EyePosition"]        = std::array {
+		static_cast<float>(context.ortho_w) / 2.0f,
+		static_cast<float>(context.ortho_h) / 2.0f,
+		1000.0f,
+	};
+ 
+
 
     u32 maxcount = particle_obj.maxcount;
     maxcount     = std::min(maxcount, 20000u);


### PR DESCRIPTION
Set a particle-specific g_EyePosition for scene particles so spritetrail rendering has a stable view direction in orthographic scenes.
    
This mirrors the fix direction used in linux-wallpaperengine's particle trail handling.
    
Reference: https://github.com/Almamu/linux-wallpaperengine


before

https://github.com/user-attachments/assets/586059dd-f315-4464-8cb0-4ba1cde0e469

after

https://github.com/user-attachments/assets/28dc735d-9e27-47ef-80bf-2d4e981709c1

