### PR TITLE
Fix off-aspect scene wallpapers being stretched

### DIFF
--- a/src/Scene/Parse/WPSceneParser.cpp
+++ b/src/Scene/Parse/WPSceneParser.cpp
@@ -784,6 +784,8 @@ void ParseImageObj(ParseContext& context, wpscene::WPImageObject& img_obj) {
     bool hasEffect = count_eff > 0;
     bool isCompose = (wpimgobj.image == "models/util/composelayer.json");
 
+    if (wpimgobj.image == "models/util/projectlayer.json") return;
+
     // No-effect fullscreen / compose layers contribute nothing on their own
     // (they just sample `_rt_default` and write it back). Mark as elidable
     // so the render-graph builder drops them when unreferenced, or routes


### PR DESCRIPTION
Scenes whose design canvas isn't 16:9 (e.g. 5160x2160) rendered stretched to fill the output instead of cropped.

The projectlayer compositor re-renders the whole frame at the scene's design resolution, which squashes off-aspect content onto a 16:9 output. The frame is already correctly composited in `_rt_default` by the layer passes, so this skips the projectlayer and presents it as-is.

Verified with SceneViewer on two off-aspect workshop scenes on a 16:9 monitor: content now keeps its aspect ratio.

Related: waywallen/waywallen#52