### PR TITLE
Fix mirror wrap mode clamping animations to the last keyframe

### DIFF
--- a/src/Scene/Scene/Scene.cpp
+++ b/src/Scene/Scene/Scene.cpp
@@ -62,13 +62,24 @@ float animation_frame(const SceneAnimationCurve& curve, double runtime) {
     absorb_last(curve.c2);
     if (end <= 0) return frame;
 
-    bool loop = curve.wraploop || curve.mode == "loop" || curve.mode == "repeat";
+    const float ef  = static_cast<float>(end);
+    bool        loop = curve.wraploop || curve.mode == "loop" || curve.mode == "repeat";
     if (loop) {
-        frame = std::fmod(frame, static_cast<float>(end));
-        if (frame < 0.0f) frame += static_cast<float>(end);
+        frame = std::fmod(frame, ef);
+        if (frame < 0.0f) frame += ef;
         return frame;
     }
-    return std::clamp(frame, 0.0f, static_cast<float>(end));
+    // Mirror mode ping-pongs 0 -> end -> 0 with period 2*end. Without this it
+    // fell through to clamp(), pinning the value to the last keyframe forever
+    // after one forward pass — e.g. a blink's eye-closed pose (value=1 at the
+    // last key) would stick on, leaving the eye permanently transparent.
+    if (curve.mode == "mirror") {
+        float period = 2.0f * ef;
+        float m      = std::fmod(frame, period);
+        if (m < 0.0f) m += period;
+        return m <= ef ? m : (period - m);
+    }
+    return std::clamp(frame, 0.0f, ef);
 }
 
 float eval_segment(const SceneAnimationKey& a, const SceneAnimationKey& b, float frame) {


### PR DESCRIPTION
## Problem

Animations authored with wrap mode `"mirror"` only play **once** (forward), then
freeze on the final keyframe's value forever — the animated value never returns
to its rest state.

Reproduced on wallpaper scene workshop id `2981289585` (two 银狼 / Silver Wolf
characters). Each character's blink is driven by a `multiply` shader-value
animation on an effect material:

```jsonc
// constantshadervalues → "multiply"
{
  "value": 0,                          // base / rest state = eye open
  "animation": {
    "c0": [ {"frame":0,"value":0}, {"frame":50,"value":0}, {"frame":60,"value":1} ],
    "options": { "fps": 30, "length": 60, "mode": "mirror", "wraploop": null }
  }
}
```

**Before fix — eye closes on the first blink (~2s) and never re-opens:**

https://github.com/user-attachments/assets/ba866a40-0bfb-42cd-95a3-3d1237b219f4


## Root cause

`SceneAnimationCurve::animation_frame()` (`src/Scene/Scene/Scene.cpp`) handles
`loop` / `repeat` / `wraploop` but **not `mirror`**:

```cpp
bool loop = curve.wraploop || curve.mode == "loop" || curve.mode == "repeat";
if (loop) {
    frame = std::fmod(frame, end);
    ...
    return frame;
}
return std::clamp(frame, 0.0f, end);   // ← mirror falls through here
```

A `mirror` curve is neither looping nor single-play; it falls through to
`std::clamp`, so once `runtime` exceeds `length/fps` the frame is pinned to
`end` and `eval_axis` returns `keys.back().value` forever — the eye-closed pose
(value `1` at the last key) sticks on.

(`SceneAnimationCurve` only; puppet bone animation resolves mirror correctly via
its own `WPPuppet::Animation::getInterpolationInfo`.)

## Fix

Implement the mirror ping-pong: fold the running frame into a `2 * end` period,
then reflect the second half back into `[0, end]`.

```cpp
const float ef  = static_cast<float>(end);
bool        loop = curve.wraploop || curve.mode == "loop" || curve.mode == "repeat";
if (loop) {
    frame = std::fmod(frame, ef);
    if (frame < 0.0f) frame += ef;
    return frame;
}
// Mirror mode ping-pongs 0 -> end -> 0 with period 2*end. Without this it
// fell through to clamp(), pinning the value to the last keyframe forever
// after one forward pass.
if (curve.mode == "mirror") {
    float period = 2.0f * ef;
    float m      = std::fmod(frame, period);
    if (m < 0.0f) m += period;
    return m <= ef ? m : (period - m);
}
return std::clamp(frame, 0.0f, ef);
```

Because `animation_frame()` is shared by `EvaluateScalar` / `EvaluateVec3`, the
fix also covers `mirror`-mode field animations (origin/scale/rotation/alpha) and
camera-path curves, not just shader values.

**After fix — eyes blink open → closed → open cyclically (~4s period):**

https://github.com/user-attachments/assets/87be6218-daaf-4296-a56b-90b40272db12

## Testing

Built and ran `waywallen-wescene-renderer` against workshop id `2981289585`:

| | eyes at 4s (between blinks) |
|---|---|
| **Before** | stuck closed |
| **After** | open (pupils visible) |

