### PR TITLE
build: reject cmake 4.4+ which breaks clang module BMIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,16 @@ if(CMAKE_VERSION VERSION_LESS_EQUAL "4.3.0")
         "Use CMake 4.3.1 or newer.")
 endif()
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4.0" AND NOT WAYWALLEN_ALLOW_UNTESTED_CMAKE)
+    message(FATAL_ERROR
+        "CMake ${CMAKE_VERSION} is not supported. "
+        "With CMake 4.4 and newer, Clang 22 crashes while loading the wescene.pkg.parse BMI "
+        "(\"malformed or corrupted precompiled file: 'declaration ID out-of-range for AST file'\") "
+        "when compiling the cross-target consumers of wescene.scene_wallpaper. "
+        "Use CMake >=4.3.1 <4.4, as pinned in environment.yml, "
+        "or pass -DWAYWALLEN_ALLOW_UNTESTED_CMAKE=ON to bypass this check.")
+endif()
+
 set(OWE_PLUGIN_VERSION 0.2.0)
 set(OWE_WAYWALLEN_PLUGIN_ID org.waywallen.open-wallpaper-engine)
 set(OWE_WAYWALLEN_PLUGIN_UPDATE_URL


### PR DESCRIPTION

Refs #52.

With CMake 4.4, Clang 22 crashes while loading the `wescene.pkg.parse` BMI when
compiling the cross-target consumers of `wescene.scene_wallpaper`
(`waywallen/scene_main.cpp`, `viewer/SceneViewer.cpp`):

```
fatal error: malformed or corrupted precompiled file:
  'declaration ID out-of-range for AST file'
clang++: error: clang frontend command failed with exit code 139
```

`environment.yml` already pins `cmake>=4.3.1,<4.4`, but nothing enforced the
upper bound at configure time. Distributions that ship CMake 4.4 (Arch,
CachyOS, EndeavourOS) therefore fail ~2700 targets into the build with a
compiler crash that gives no hint about the cause — see the reports in #52.

This does not fix building under 4.4; it makes the unsupported configuration
fail immediately with an actionable message, mirroring the existing lower-bound
guard directly above it. The `WAYWALLEN_ALLOW_UNTESTED_CMAKE` escape hatch
follows the existing `WAYWALLEN_ALLOW_NONCLANG` idiom.

### Why CMake is the trigger

Same tree, same Clang 22.1.8, same flags, only the CMake version swapped.
Configuring this project generates a very different build graph:

| | CMake 4.4.0 | CMake 4.3.4 |
|---|---|---|
| synthesized `@synth_N` BMI targets | **660** | **0** |
| `rstd.std@synth_*` targets | 241 | 0 |

CMake 4.4 synthesizes BMI-only targets that 4.3 does not emit at all, and Clang
22 segfaults while compiling one of them. On current `main` the first casualty
is in the `rstd` dependency, before any project module is reached:

```
FAILED: _deps/rstd-build/src/std/CMakeFiles/rstd.std@synth_0.dir/15897c40f11f.bmi
clang++: error: clang frontend command failed with exit code 139
```

Building the v0.1.12-fix tag the same way instead surfaced it later, as
`declaration ID out-of-range for AST file` while loading the
`wescene.pkg.parse` BMI. Both are the same underlying failure: Clang 22 cannot
handle the BMIs produced for CMake 4.4's synthesized module targets in a graph
this size.

Because the crash also occurs inside a third-party dependency's modules,
restructuring this project's own module graph does not avoid it.

Clang emits a preprocessed reproducer for the crash, so this is likely worth an
upstream LLVM report as well; I can attach it if useful.

### Testing

- CMake 4.4.0 → fails at configure with the new message.
- CMake 4.3.4 → guard does not fire; configure proceeds normally.
- CMake 4.4.0 with `-DWAYWALLEN_ALLOW_UNTESTED_CMAKE=ON` → guard does not fire.
