### PR TITLE
scene: bind all cameraparallax fields to user properties

### DIFF
--- a/src/Scene/Pkg/Parse/Uniform/WPUniformSource.cpp
+++ b/src/Scene/Pkg/Parse/Uniform/WPUniformSource.cpp
@@ -278,7 +278,14 @@ void WPUniformSceneState::Advance(const SceneFrame& frame) {
 void WPUniformSceneState::ApplyUserProperty(std::string_view field, const Json& property) {
     auto value = UserScalar(property);
     if (value.is_none()) return;
-    if (field == "cameraparallaxmouseinfluence") {
+    if (field == "cameraparallax") {
+        m_camera_parallax.enable = *value >= 0.5f;
+    } else if (field == "cameraparallaxamount") {
+        m_camera_parallax.amount = *value;
+    } else if (field == "cameraparallaxdelay") {
+        m_camera_parallax.delay = *value;
+        SetPointerDelay(*value);
+    } else if (field == "cameraparallaxmouseinfluence") {
         m_camera_parallax.mouse_influence = *value;
     } else if (field == "camerashake") {
         m_camera_shake.enable = *value >= 0.5f;

--- a/src/Scene/Pkg/Parse/WPSceneParser.cpp
+++ b/src/Scene/Pkg/Parse/WPSceneParser.cpp
@@ -2461,16 +2461,17 @@ void InitContext(ParseContext& context, fs::VFS& vfs, const wpscene::SceneMetada
         cam_para.mouse_influence                = sc.general.cameraparallaxmouseinfluence;
         context.uniform_state->CameraParallax() = cam_para;
         context.uniform_state->SetPointerDelay(cam_para.delay);
-        if (auto it = sc.general.user_bindings.find("cameraparallaxmouseinfluence");
-            it != sc.general.user_bindings.end()) {
-            auto state =
-                mut_ref<WPUniformSceneState>::from_raw_parts(context.uniform_state.as_ptr());
-            auto field = it->first;
-            scene.RegisterUserPropertyBinding(String::make(as_str(it->second).unwrap()),
-                                              Box<dyn<FnMut<void(const Json&)>>>::make(
-                                                  [state, field](const Json& property) mutable {
-                                                      state->ApplyUserProperty(field, property);
-                                                  }));
+        for (const auto& [field, key] : sc.general.user_bindings) {
+            if (field == "cameraparallax" || field == "cameraparallaxamount" ||
+                field == "cameraparallaxdelay" || field == "cameraparallaxmouseinfluence") {
+                auto state =
+                    mut_ref<WPUniformSceneState>::from_raw_parts(context.uniform_state.as_ptr());
+                scene.RegisterUserPropertyBinding(String::make(as_str(key).unwrap()),
+                                                  Box<dyn<FnMut<void(const Json&)>>>::make(
+                                                      [state, field](const Json& property) mutable {
+                                                          state->ApplyUserProperty(field, property);
+                                                      }));
+            }
         }
     }
     {

--- a/tests/scene_runtime_tests.cpp
+++ b/tests/scene_runtime_tests.cpp
@@ -401,6 +401,31 @@ TEST(WPUniformSourceRuntimeAlpha, VisibleTrueRestoresLayerAlpha) {
     EXPECT_FLOAT_EQ(restored[rstd::usize(3)], 0.35f);
 }
 
+TEST(WPUniformSourceParallax, UserPropertiesDriveEveryParallaxField) {
+    auto state = Arc<owe::WPUniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->CameraParallax() = { true, 0.03f, 0.1f, 0.36f };
+
+    auto disable = owe::ParseJson(R"({"value":false})").unwrap();
+    state->ApplyUserProperty("cameraparallax", disable);
+    EXPECT_FALSE(state->CameraParallax().enable);
+
+    auto enable = owe::ParseJson(R"({"value":true})").unwrap();
+    state->ApplyUserProperty("cameraparallax", enable);
+    EXPECT_TRUE(state->CameraParallax().enable);
+
+    auto amount = owe::ParseJson(R"({"value":0.25})").unwrap();
+    state->ApplyUserProperty("cameraparallaxamount", amount);
+    EXPECT_FLOAT_EQ(state->CameraParallax().amount, 0.25f);
+
+    auto delay = owe::ParseJson(R"({"value":0.5})").unwrap();
+    state->ApplyUserProperty("cameraparallaxdelay", delay);
+    EXPECT_FLOAT_EQ(state->CameraParallax().delay, 0.5f);
+
+    auto influence = owe::ParseJson(R"({"value":0.75})").unwrap();
+    state->ApplyUserProperty("cameraparallaxmouseinfluence", influence);
+    EXPECT_FLOAT_EQ(state->CameraParallax().mouse_influence, 0.75f);
+}
+
 TEST(WPUniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
     owe::Scene scene;
     scene.SetOrtho({ i32(3840), i32(2160) });


### PR DESCRIPTION

Refs #41 ("enabling/disabling mouse movement does nothing").

Only `cameraparallaxmouseinfluence` was registered as a user-property binding.
A wallpaper that exposes the parallax toggle, amount or delay as a user
property had no effect at runtime: `parallax.enable` stayed frozen at its
parse-time value forever, so switching parallax off in the wallpaper's own
options did nothing.

The `camerashake` block immediately below already does this correctly — it
loops over the bindings and registers all four of its fields, boolean included.
This change makes `cameraparallax` follow the same pattern, and handles the
three missing fields in `ApplyUserProperty`.

`cameraparallaxdelay` also re-applies `SetPointerDelay`, because the pointer
delay is stored separately from `WPUniformCameraParallax` and is otherwise only
applied once at parse time.

### Testing

Adds `WPUniformSourceParallax.UserPropertiesDriveEveryParallaxField`, which
drives all four fields through `ApplyUserProperty` and asserts the state
changes. Verified that it **fails** without the accompanying source change and
passes with it; the rest of `scene_runtime_tests` stays green (18/18).

Note the new test covers `ApplyUserProperty`; the binding registration in
`WPSceneParser` is not unit-tested here, as that would require parsing a full
scene.
