### PR TITLE
scene: stop a sound layer when its layer is hidden

### DIFF
--- a/src/Scene/Pkg/Parse/WPSoundParser.cpp
+++ b/src/Scene/Pkg/Parse/WPSoundParser.cpp
@@ -214,7 +214,10 @@ Arc<dyn<SceneSoundControl>> WPSoundParser::Parse(const wpscene::SoundObject& obj
     Option<Arc<SceneAudioAverage>> audio_average = None();
     if (scene != nullptr) audio_average = Some(scene->AudioAverageHandle());
     auto state = Arc<WPSoundState>::make();
-    state->playing.store(! obj.startsilent, Ordering::Release);
+    // The node's sound control is attached after its visibility is applied, so
+    // a layer that starts hidden has to be silenced here or it would play until
+    // something toggles it.
+    state->playing.store(obj.visible && ! obj.startsilent, Ordering::Release);
     state->volume.store(f32(config.volume), Ordering::Release);
     auto control = Arc<dyn<SceneSoundControl>>::make(WPSoundControl(state.clone()));
     auto ss      = std::make_unique<WPSoundStream>(

--- a/src/Scene/Scene/Scene.cppm
+++ b/src/Scene/Scene/Scene.cppm
@@ -1321,6 +1321,16 @@ public:
     bool  Visible() const { return m_visible; }
     float UserAlpha() const { return m_user_alpha; }
     void  SetVisible(bool v) {
+        // A sound layer is audible only while its layer is visible, which is
+        // how scenes implement track selectors: the selector binds each sound
+        // layer's visibility to a user property.
+        if (m_sound_control.is_some() && v != m_visible) {
+            if (v) {
+                (*m_sound_control)->Play();
+            } else {
+                (*m_sound_control)->Stop();
+            }
+        }
         m_visible            = v;
         m_visible_overridden = true;
     }

--- a/tests/script_runtime_tests.cpp
+++ b/tests/script_runtime_tests.cpp
@@ -1811,6 +1811,20 @@ TEST(ScriptScene, ParticleInstanceAndPlaybackUseNodeCapability) {
     EXPECT_NEAR(LastScalar(fs), 1024.8, 1e-5);
 }
 
+TEST(SceneNodeSound, VisibilityStartsAndStopsTheSoundControl) {
+    auto layer = Arc<owe::SceneNode>::make();
+    auto state = Arc<SoundControlState>::make();
+    layer->SetSoundControl(
+        Arc<dyn<owe::SceneSoundControl>>::make(SoundControlProbe { state.clone() }));
+    ASSERT_TRUE(state->playing);
+
+    layer->SetVisible(false);
+    EXPECT_FALSE(state->playing);
+
+    layer->SetVisible(true);
+    EXPECT_TRUE(state->playing);
+}
+
 TEST(ScriptScene, SoundVolumeUsesSoundControl) {
     auto root  = Arc<owe::SceneNode>::make();
     auto layer = Arc<owe::SceneNode>::make();


### PR DESCRIPTION

Refs #54.

Scene sound layers are started unconditionally and never gated on visibility,
so every sound object in a scene plays at once. Wallpapers that offer a track
selector implement it by binding each sound layer's visibility to a user
property, so picking a track starts the new one without stopping the others —
which is what #54 describes.

The forwarding pattern already exists one method away: `SceneNode::SetVolume`
forwards to the node's sound control, but `SetVisible` does not, and
`SceneNode::SoundControl()` had no callers anywhere in the repo — the control
was attached and then never consulted.

Two changes:

- `SceneNode::SetVisible` forwards visibility transitions to the sound control.
  Putting it there rather than in `Scene::SetNodeVisible` covers every caller in
  one place: the user-property path, the script path, and the parser.
- `WPSoundParser` gates the initial `playing` state on the layer's visibility.
  This is needed because `ParseSoundObj` applies visibility *before* it attaches
  the control, so a layer that starts hidden would otherwise play until
  something toggled it.

### Testing

Adds `SceneNodeSound.VisibilityStartsAndStopsTheSoundControl`, using the
`SoundControlProbe` fixture already in `script_runtime_tests.cpp`. Verified that
it fails without the source change and passes with it.

Since `SetVisible` now has a side effect, I also compared the full `ctest` run
against `main`: identical failure set (all pre-existing corpus tests that need
wallpaper fixtures), with only the new test added.

One behavioural note worth your call: `Play()` bumps `play_seq`, so re-selecting
a track restarts it from the beginning rather than resuming. That seems right
for a track selector, but if you would rather have resume semantics, `Pause()`
on hide plus a `Resume()` that does not bump `play_seq` would do it — happy to
change it.
