### PR TITLE
source: normalize registered Steam library paths

### DIFF
--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
@@ -756,6 +756,15 @@ equal(#source_items, 2, "source scan item count")
 equal(source_items[1].resource, item_dir .. "/scene.pkg", "source scan resource")
 equal(source_items[1].external_id, "3765064055", "source Workshop subscription id")
 equal(source_items[2].external_id, nil, "local project must not expose a subscription id")
+
+-- Registering a library that already points inside steamapps must still scan.
+for _, suffix in ipairs({ "/", "/steamapps", "/steamapps/workshop/content/" .. project.WE_APPID }) do
+    local nested_ctx = {}
+    for key, value in pairs(source_ctx) do nested_ctx[key] = value end
+    nested_ctx.libraries = function() return { steam_root .. suffix } end
+    equal(#main.source.scan(nested_ctx), 2, "source scan from library path '" .. suffix .. "'")
+end
+
 project.classify = original_classify
 
 print("OWE waywallen Lua contract fixtures passed")

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/project.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/project.lua
@@ -6,6 +6,20 @@ M.ASSETS_REL = "/steamapps/common/wallpaper_engine/assets"
 M.PROJECTS_REL = "/steamapps/common/wallpaper_engine/projects"
 M.LOCAL_DIRS = { "defaultprojects", "myprojects" }
 
+-- Users are asked to register the directory that *contains* steamapps, but they
+-- routinely pick steamapps itself, or the workshop content directory they can
+-- see the wallpapers in. Fold those back to the Steam root, so the paths built
+-- from WORKSHOP/PROJECTS_REL still resolve instead of silently missing.
+function M.normalize_root(path)
+    if type(path) ~= "string" then return path end
+    local root = path:gsub("/+$", "")
+    root = root:gsub("/steamapps/workshop/content/" .. M.WE_APPID .. "$", "")
+    root = root:gsub("/steamapps/workshop/content$", "")
+    root = root:gsub("/steamapps/workshop$", "")
+    root = root:gsub("/steamapps$", "")
+    return root
+end
+
 local VIDEO_EXTS = { mp4 = true, webm = true, mkv = true, avi = true, mov = true }
 
 local SCENE_BASE_BY_FILE = {

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/source.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/source.lua
@@ -54,7 +54,8 @@ end
 function M.scan(ctx)
     local entries = {}
 
-    for _, steam_root in ipairs(ctx.libraries()) do
+    for _, library in ipairs(ctx.libraries()) do
+        local steam_root = project_util.normalize_root(library)
         local workshop = steam_root .. project_util.WORKSHOP
         if not ctx.fs.exists(workshop) then
             ctx.log("wallpaper_engine: no WE workshop under " .. steam_root)


### PR DESCRIPTION

Refs #45.

The library path a user registers is concatenated with `WORKSHOP`
(`/steamapps/workshop/content/431960`) and `PROJECTS_REL`, so it has to be the
directory that *contains* `steamapps`. Users routinely pick `steamapps` itself,
or the workshop content directory they can actually see their wallpapers in.
The concatenation then points at a path that does not exist, `scan_container`
returns early, and the scan reports zero wallpapers.

`normalize_root` folds those variants back to the Steam root before the paths
are built, and tolerates trailing slashes:

| registered path | scanned as |
|---|---|
| `…/Steam` | `…/Steam` |
| `…/Steam/` | `…/Steam` |
| `…/Steam/steamapps` | `…/Steam` |
| `…/Steam/steamapps/workshop` | `…/Steam` |
| `…/Steam/steamapps/workshop/content/431960` | `…/Steam` |

### Testing

`tests/contract.lua` gains a case that runs the existing source-scan fixture
from three nested library paths. Verified that it fails without the change
(the scan returns 0 entries) and passes with it.

Worth noting separately: nothing surfaces this to the user today — a scan that
fails and a scan that legitimately found nothing both end up as
"Scanned 0 wallpapers". I have opened a companion PR against waywallen for
that half.
