### PR TITLE
cmake: keep imported pkg-config targets out of the module profile

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,14 @@ find_package(Vulkan REQUIRED)
 find_package(Freetype REQUIRED)
 pkg_check_modules(LZ4 REQUIRED liblz4)
 pkg_check_modules(FONTCONFIG REQUIRED IMPORTED_TARGET fontconfig)
+# A .pc file may carry cflags that are not include paths, and pkg_check_modules
+# puts those on INTERFACE_COMPILE_OPTIONS. They then reach the module consumers
+# that link this target but not the module providers, which splits the C++20
+# module usage profile and makes CMake 4.4 synthesize a BMI for every provider
+# in the closure. Compile options come from the top-level profile; imported
+# targets contribute include directories and libraries.
+# (Seen with distro zlib-ng, whose .pc adds -DWITH_GZFILEOP via freetype2.)
+set_property(TARGET PkgConfig::FONTCONFIG PROPERTY INTERFACE_COMPILE_OPTIONS "")
 
 include(TestBigEndian)
 test_big_endian(ENDIAN)


### PR DESCRIPTION

Refs #52.

Arch and CachyOS ship zlib-ng as their `zlib`. Its `.pc` file adds `-DWITH_GZFILEOP`, and freetype2 pulls zlib in through `Requires`, so on those systems `pkg-config --cflags fontconfig` returns that flag. `pkg_check_modules(... IMPORTED_TARGET ...)` places it on `INTERFACE_COMPILE_OPTIONS`, from where it reaches exactly one target, `owe-parse`, the only one linking `PkgConfig::FONTCONFIG`, and none of the module providers `owe-parse` imports from.

That single option is enough to split the module profile. CMake 4.4 decides BMI compatibility by hashing a target's `COMPILE_OPTIONS` (with warning flags filtered out), `CXX_STANDARD`, `CXX_EXTENSIONS` and `CXX_STANDARD_REQUIRED`. The extra option puts `owe-parse` in a class of its own, so CMake synthesizes a BMI for every provider in its closure, and each synthetic target re-imports under the same profile. In this tree that cascades into 663 synthesized BMI edges across 23 targets. Those duplicate BMIs are what trips the Clang `ASTReader` crash described in `BUILD.md`.

This is the same "one compile profile at the top level" rule already documented there. The difference is that the divergence arrives from a `.pc` file rather than a `target_compile_options` call, which also means it cannot appear in an environment with stock zlib, where the flag does not exist.

Measured on CachyOS with Clang/LLD 22.1.8, Ninja 1.13.2, CMake 4.4.0, 16 cores, `-DBUILD_WEWEB=OFF`:

| | synthesized BMI edges | `-j16` builds that failed |
|---|---|---|
| before | 663 | 4 of 4 |
| after | 0 | 0 of 3 |

I verified the modules are genuinely compiled rather than the build stopping early: 296 `.pcm` files are produced, including `rstd-sys.io.stdio.pcm`, which is the module Clang was crashing on. The only remaining failure in my runs is local to my machine (installed `waywallen-bridge` headers older than `main` expects) and is unrelated to this change.

Include directories live on `INTERFACE_INCLUDE_DIRECTORIES` and are unaffected. Nothing under `src/` or `third_party/` includes `zlib.h` or calls the `gz*` API, so dropping the macro does not change behaviour here.

More generally, any `pkg_check_modules(... IMPORTED_TARGET ...)` whose `.pc` carries a flag that is not `-I` or `-W` can cause this, even when linked `PRIVATE`. On this machine `gstreamer-1.0` (`-pthread -DWITH_GZFILEOP`) and `libpulse` (`-D_REENTRANT`) are in the same position. I left them alone since neither is currently linked into a module target, but they would produce the same effect if that changed.
