### PR TITLE
fix: keep user-property image bindings alive to stop a use-after-free (#66)

### DIFF
--- a/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
@@ -178,11 +178,10 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                          : None<WallpaperLayerId>());
     if (! wpimgobj.visible_user.empty())
         spImgNode->SetVisibleUserBinding(ToSceneUserVisibilityBinding(wpimgobj.visible_user));
-    Vec<SceneMaterial*> image_property_materials;
-    auto                track_image_property_material = [&](SceneMaterial* mat) {
-        if ((wpimgobj.color_user_key.empty() && wpimgobj.alpha_user_key.empty()) || mat == nullptr)
-            return;
-        image_property_materials.emplace_back(mat);
+    Vec<std::shared_ptr<SceneMaterial>> image_property_materials;
+    auto track_image_property_material = [&](std::shared_ptr<SceneMaterial> mat) {
+        if ((wpimgobj.color_user_key.empty() && wpimgobj.alpha_user_key.empty()) || ! mat) return;
+        image_property_materials.emplace_back(std::move(mat));
     };
     Option<Arc<PuppetLayer>> image_puppet_layer;
     if (puppet.is_some() && has_bones) {
@@ -386,7 +385,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
         if (control.is_some()) spImgNode->SetVideoControl(rstd::move(*control));
     }
     mesh.AddMaterial(std::move(material));
-    track_image_property_material(mesh.MaterialSlots().back().get());
+    track_image_property_material(mesh.MaterialSlots().back());
     RegisterMaterialBindings(
         *context.scene,
         mesh.MaterialSlots().front(),
@@ -430,7 +429,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
         const auto supplemental_uv_scale = Texture0UvScale(supplemental_material);
         const auto supplemental_slot     = static_cast<uint32_t>(mesh.MaterialSlots().size());
         mesh.AddMaterial(std::move(supplemental_material));
-        track_image_property_material(mesh.MaterialSlots().back().get());
+        track_image_property_material(mesh.MaterialSlots().back());
         RegisterMaterialBindings(
             *context.scene,
             mesh.MaterialSlots().back(),
@@ -526,7 +525,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 mask_shaderInfo   = rstd::move(mask_build.shader_info);
                 uint32_t pre_slot = (uint32_t)mesh.MaterialSlots().size();
                 mesh.AddMaterial(std::move(mask_scene_mat));
-                track_image_property_material(mesh.MaterialSlots().back().get());
+                track_image_property_material(mesh.MaterialSlots().back());
                 mesh.Submeshes().emplace_back();
                 auto& pre_sm = mesh.Submeshes().back();
                 MdlParser::GenMaskSubmeshFromMdl(pre_sm,
@@ -563,7 +562,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 LoadConstvalue(clip_scene_mat, clip_wpmat, clip_shaderInfo);
                 uint32_t clip_slot = (uint32_t)mesh.MaterialSlots().size();
                 mesh.AddMaterial(std::move(clip_scene_mat));
-                track_image_property_material(mesh.MaterialSlots().back().get());
+                track_image_property_material(mesh.MaterialSlots().back());
                 mesh.Submeshes().emplace_back();
                 auto& clip_sm = mesh.Submeshes().back();
                 MdlParser::GenMaskSubmeshFromMdl(clip_sm,
@@ -844,7 +843,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                     }
                 }
                 spMesh->AddMaterial(std::move(material));
-                track_image_property_material(spMesh->MaterialSlots().back().get());
+                track_image_property_material(spMesh->MaterialSlots().back());
                 Option<ref<wpscene::Material>> binding_fallback;
                 if (user_texture_fallback.is_some()) {
                     binding_fallback = Some(ref<wpscene::Material>::from_raw_parts(
@@ -902,7 +901,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                                                           image_node_id,
                                                           as_str(effect_composite).unwrap());
                             spMesh->AddMaterial(std::move(mask_material));
-                            track_image_property_material(spMesh->MaterialSlots().back().get());
+                            track_image_property_material(spMesh->MaterialSlots().back());
 
                             wpscene::Material clip_wpmat        = wpmat.clone();
                             clip_wpmat.combos["CLIPPINGTARGET"] = 1;
@@ -933,7 +932,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                                                           image_node_id,
                                                           as_str(effect_composite).unwrap());
                             spMesh->AddMaterial(std::move(clip_material));
-                            track_image_property_material(spMesh->MaterialSlots().back().get());
+                            track_image_property_material(spMesh->MaterialSlots().back());
                         }
                     }
                     return true;
@@ -1132,13 +1131,13 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
     if (! wpimgobj.color_user_key.empty()) {
         context.scene->RegisterImageColorUserBinding(
             String::make(as_str(wpimgobj.color_user_key).unwrap()),
-            *spImgNode,
+            spImgNode,
             image_property_materials.as_slice());
     }
     if (! wpimgobj.alpha_user_key.empty()) {
         context.scene->RegisterImageAlphaUserBinding(
             String::make(as_str(wpimgobj.alpha_user_key).unwrap()),
-            *spImgNode,
+            spImgNode,
             image_property_materials.as_slice());
     }
     RegisterNodeRef(context,

--- a/src/Scene/Scene/Scene.cpp
+++ b/src/Scene/Scene/Scene.cpp
@@ -1247,34 +1247,40 @@ auto Scene::MaterialTextureUserBindings(ref<str> key) const -> slice<MaterialTex
     return bindings.is_some() ? (*bindings)->as_slice() : slice<MaterialTextureUserBinding> {};
 }
 
-void Scene::RegisterImageColorUserBinding(String key, SceneNode& node,
-                                          slice<SceneMaterial*> materials) {
+namespace
+{
+
+auto MakeImagePropertyBinding(const Arc<SceneNode>&                 node,
+                              slice<std::shared_ptr<SceneMaterial>> materials)
+    -> Scene::ImagePropertyBinding {
+    Scene::ImagePropertyBinding binding { .node = node.clone() };
+    binding.materials.reserve(materials.len());
+    for (usize index {}; index < materials.len(); ++index) {
+        binding.materials.emplace_back(materials[index]);
+    }
+    return binding;
+}
+
+} // namespace
+
+void Scene::RegisterImageColorUserBinding(String key, const Arc<SceneNode>& node,
+                                          slice<std::shared_ptr<SceneMaterial>> materials) {
     auto bindings = m_image_color_user_index.get_mut(key.as_str());
     if (bindings.is_none()) {
         (void)m_image_color_user_index.insert(key.clone(), Vec<ImagePropertyBinding> {});
         bindings = m_image_color_user_index.get_mut(key.as_str());
     }
-    ImagePropertyBinding binding { .node = rstd::addressof(node) };
-    binding.materials.reserve(materials.len());
-    for (usize index {}; index < materials.len(); ++index) {
-        binding.materials.emplace_back(materials[index]);
-    }
-    (*bindings)->push(rstd::move(binding));
+    (*bindings)->push(MakeImagePropertyBinding(node, materials));
 }
 
-void Scene::RegisterImageAlphaUserBinding(String key, SceneNode& node,
-                                          slice<SceneMaterial*> materials) {
+void Scene::RegisterImageAlphaUserBinding(String key, const Arc<SceneNode>& node,
+                                          slice<std::shared_ptr<SceneMaterial>> materials) {
     auto bindings = m_image_alpha_user_index.get_mut(key.as_str());
     if (bindings.is_none()) {
         (void)m_image_alpha_user_index.insert(key.clone(), Vec<ImagePropertyBinding> {});
         bindings = m_image_alpha_user_index.get_mut(key.as_str());
     }
-    ImagePropertyBinding binding { .node = rstd::addressof(node) };
-    binding.materials.reserve(materials.len());
-    for (usize index {}; index < materials.len(); ++index) {
-        binding.materials.emplace_back(materials[index]);
-    }
-    (*bindings)->push(rstd::move(binding));
+    (*bindings)->push(MakeImagePropertyBinding(node, materials));
 }
 
 auto Scene::ImageColorUserBindings(ref<str> key) const -> slice<ImagePropertyBinding> {

--- a/src/Scene/Scene/Scene.cppm
+++ b/src/Scene/Scene/Scene.cppm
@@ -2451,14 +2451,20 @@ public:
     void RegisterShaderComboUserBinding(String key, ShaderComboUserBinding binding);
     auto ShaderComboUserBindings(ref<str> key) const -> slice<ShaderComboUserBinding>;
 
+    // Like the material bindings above, this index is scene-wide and outlives
+    // the parse, but not every parsed node reaches the finalized scene: the
+    // prototype objects ResolveRegisteredAsset parses purely as spawn
+    // templates are dropped from the node map and die with the parse context.
+    // Retain both the node and its materials so a binding left pointing at
+    // such an object stays valid instead of dangling.
     struct ImagePropertyBinding {
-        SceneNode*          node { nullptr };
-        Vec<SceneMaterial*> materials;
+        Arc<SceneNode>                      node;
+        Vec<std::shared_ptr<SceneMaterial>> materials;
     };
-    void RegisterImageColorUserBinding(String key, SceneNode& node,
-                                       slice<SceneMaterial*> materials);
-    void RegisterImageAlphaUserBinding(String key, SceneNode& node,
-                                       slice<SceneMaterial*> materials);
+    void RegisterImageColorUserBinding(String key, const Arc<SceneNode>& node,
+                                       slice<std::shared_ptr<SceneMaterial>> materials);
+    void RegisterImageAlphaUserBinding(String key, const Arc<SceneNode>& node,
+                                       slice<std::shared_ptr<SceneMaterial>> materials);
     auto ImageColorUserBindings(ref<str> key) const -> slice<ImagePropertyBinding>;
     auto ImageAlphaUserBindings(ref<str> key) const -> slice<ImagePropertyBinding>;
 

--- a/src/Scene/SceneUserProperty.cpp
+++ b/src/Scene/SceneUserProperty.cpp
@@ -338,14 +338,12 @@ bool ApplyShaderCombos(Scene& scene, const std::string& key, const Json& propert
     return graph_changed;
 }
 
-float CurrentImageAlpha(SceneNode* node) {
-    if (! node) return 1.0f;
-    return node->IsAlphaOverridden() ? node->EffectiveAlpha() : node->BaseAlpha();
+float CurrentImageAlpha(SceneNode& node) {
+    return node.IsAlphaOverridden() ? node.EffectiveAlpha() : node.BaseAlpha();
 }
 
-Eigen::Vector3f CurrentImageColor(SceneNode* node) {
-    if (! node) return { 1.0f, 1.0f, 1.0f };
-    return node->IsColorOverridden() ? node->Color() : node->BaseColor();
+Eigen::Vector3f CurrentImageColor(SceneNode& node) {
+    return node.IsColorOverridden() ? node.Color() : node.BaseColor();
 }
 
 bool MaterialHasUniform(const SceneMaterial& material, ref<str> uniform_name) {
@@ -369,14 +367,14 @@ void ApplyImageColor(Scene& scene, const std::string& key, const Json& property)
                             coerced.value[usize(2)] };
     for (usize binding_index {}; binding_index < bindings.len(); ++binding_index) {
         const auto& binding = bindings[binding_index];
-        if (binding.node) binding.node->SetColor(color);
+        SceneNode&  node    = *binding.node;
+        node.SetColor(color);
         std::array<float, 3> color3 { color.x(), color.y(), color.z() };
         for (usize material_index {}; material_index < binding.materials.len(); ++material_index) {
-            auto* material = binding.materials[material_index];
+            const auto& material = binding.materials[material_index];
             if (! material) continue;
             const bool  has_user_alpha = MaterialHasUniform(*material, G_USERALPHA);
-            const float alpha = has_user_alpha && binding.node ? binding.node->BaseAlpha()
-                                                               : CurrentImageAlpha(binding.node);
+            const float alpha = has_user_alpha ? node.BaseAlpha() : CurrentImageAlpha(node);
             std::array<float, 4> color4 { color.x(), color.y(), color.z(), alpha };
             if (MaterialHasUniform(*material, G_COLOR4))
                 scene.SetMaterialShaderValue(*material, G_COLOR4, color4);
@@ -395,11 +393,12 @@ void ApplyImageAlpha(Scene& scene, const std::string& key, const Json& property)
     const float alpha = std::clamp(coerced.value[usize()], 0.0f, 1.0f);
     for (usize binding_index {}; binding_index < bindings.len(); ++binding_index) {
         const auto& binding = bindings[binding_index];
-        if (binding.node) binding.node->SetUserAlpha(alpha);
-        auto                 color = CurrentImageColor(binding.node);
+        SceneNode&  node    = *binding.node;
+        node.SetUserAlpha(alpha);
+        auto                 color = CurrentImageColor(node);
         std::array<float, 4> color4 { color.x(), color.y(), color.z(), alpha };
         for (usize material_index {}; material_index < binding.materials.len(); ++material_index) {
-            auto* material = binding.materials[material_index];
+            const auto& material = binding.materials[material_index];
             if (! material) continue;
             const bool has_user_alpha = MaterialHasUniform(*material, G_USERALPHA);
             if (has_user_alpha) scene.SetMaterialShaderValue(*material, G_USERALPHA, alpha);

--- a/tests/scene_user_property_tests.cpp
+++ b/tests/scene_user_property_tests.cpp
@@ -150,10 +150,10 @@ TEST(SceneUserProperty, AppliesRegisteredMaterialTextureBinding) {
 }
 
 TEST(SceneUserProperty, AppliesRegisteredImageColorBinding) {
-    owe::Scene                          scene;
-    owe::SceneNode                      node;
-    owe::SceneMaterial                  material;
-    rstd::array<owe::SceneMaterial*, 1> materials { &material };
+    owe::Scene scene;
+    auto       node     = Arc<owe::SceneNode>::make();
+    auto       material = std::make_shared<owe::SceneMaterial>();
+    rstd::array<std::shared_ptr<owe::SceneMaterial>, 1> materials { material };
     scene.RegisterImageColorUserBinding(String::make("tint"_str), node, materials.as_slice());
 
     auto property = rstd::json::from_str(R"({"type":"color","value":"0.2 0.4 0.6"})"_str).unwrap();
@@ -162,10 +162,51 @@ TEST(SceneUserProperty, AppliesRegisteredImageColorBinding) {
     auto bindings = scene.ImageColorUserBindings("tint"_str);
     ASSERT_EQ(bindings.len(), usize(1));
     ASSERT_EQ(bindings[usize()].materials.len(), usize(1));
-    EXPECT_EQ(bindings[usize()].materials[usize()], &material);
-    EXPECT_FLOAT_EQ(node.Color().x(), 0.2f);
-    EXPECT_FLOAT_EQ(node.Color().y(), 0.4f);
-    EXPECT_FLOAT_EQ(node.Color().z(), 0.6f);
+    EXPECT_EQ(bindings[usize()].materials[usize()], material);
+    EXPECT_FLOAT_EQ(node->Color().x(), 0.2f);
+    EXPECT_FLOAT_EQ(node->Color().y(), 0.4f);
+    EXPECT_FLOAT_EQ(node->Color().z(), 0.6f);
+}
+
+// A parsed object that never reaches the finalized scene (a spawn-template
+// prototype, say) is released with the parse context, but its image bindings
+// stay in the scene-wide index and are applied right after the parse. The
+// index has to keep those targets alive on its own.
+TEST(SceneUserProperty, KeepsImageColorBindingTargetsAliveAfterParse) {
+    owe::Scene scene;
+    {
+        auto node     = Arc<owe::SceneNode>::make();
+        auto material = std::make_shared<owe::SceneMaterial>();
+        rstd::array<std::shared_ptr<owe::SceneMaterial>, 1> materials { material };
+        scene.RegisterImageColorUserBinding(String::make("tint"_str), node, materials.as_slice());
+    }
+
+    auto property = rstd::json::from_str(R"({"type":"color","value":"0.2 0.4 0.6"})"_str).unwrap();
+    (void)owe::SceneUserPropertyApplier::Apply(scene, "tint", property);
+
+    auto bindings = scene.ImageColorUserBindings("tint"_str);
+    ASSERT_EQ(bindings.len(), usize(1));
+    ASSERT_EQ(bindings[usize()].materials.len(), usize(1));
+    EXPECT_FLOAT_EQ(bindings[usize()].node->Color().x(), 0.2f);
+    EXPECT_FLOAT_EQ(bindings[usize()].node->Color().y(), 0.4f);
+    EXPECT_FLOAT_EQ(bindings[usize()].node->Color().z(), 0.6f);
+}
+
+TEST(SceneUserProperty, KeepsImageAlphaBindingTargetsAliveAfterParse) {
+    owe::Scene scene;
+    {
+        auto node     = Arc<owe::SceneNode>::make();
+        auto material = std::make_shared<owe::SceneMaterial>();
+        rstd::array<std::shared_ptr<owe::SceneMaterial>, 1> materials { material };
+        scene.RegisterImageAlphaUserBinding(String::make("fade"_str), node, materials.as_slice());
+    }
+
+    auto property = rstd::json::from_str(R"({"type":"slider","value":0.25})"_str).unwrap();
+    (void)owe::SceneUserPropertyApplier::Apply(scene, "fade", property);
+
+    auto bindings = scene.ImageAlphaUserBindings("fade"_str);
+    ASSERT_EQ(bindings.len(), usize(1));
+    EXPECT_FLOAT_EQ(bindings[usize()].node->UserAlpha(), 0.25f);
 }
 
 TEST(SceneUserProperty, AppliesRegisteredParticleOverrideBinding) {


### PR DESCRIPTION
Fixes #66.

### The bug

The scene-wide user-property indexes store raw pointers published during parse:

```cpp
struct ShaderUserBinding {
    SceneMaterial* material { nullptr };
    String         uniform;
};
```

But not every parsed node reaches the finalized scene. `ResolveRegisteredAsset`
parses prototype objects purely as spawn templates and then drops them from
`node_id_map`, so `FinalizeScene` never attaches them. Their only owners are
`ParseContext` members (`dynamic_model_prototypes`, `uniform_configs`), which die
with the `ParseContext` at the end of `WPSceneParser::Parse`.

`ParseModelObj` has already called `RegisterShaderUserVarIndex` for those
materials by then, so `Scene::m_shader_user_index` keeps pointing at freed
memory. `loadScene` applies user properties immediately afterwards, and
`Scene::SetMaterialShaderValue` reaches `SceneMaterial::SetShaderValue` ->
`std::map::operator[]` — which is not just a read, it *inserts*. The write lands
in the freed region and corrupts the heap; the later `free(): invalid pointer` /
`chunks in smallbin corrupted` aborts are the allocator tripping over the damage,
not the real culprit.

The comment above `RegisterShaderUserVarIndex` already states the invariant that
breaks here:

> Must be called after SceneMaterial has entered its stable mesh-owned allocation.

For a prototype node that allocation is not stable.

### The fix

Make every handle in those indexes weak, matching the ownership that already
exists — materials are `std::shared_ptr` inside their `SceneMesh`, nodes are
`Arc` in the graph:

* `std::weak_ptr<SceneMaterial>` in `ShaderUserBinding`, `ShaderComboUserBinding`,
  `MaterialTextureUserBinding` and `ImagePropertyBinding::materials`;
* `Weak<SceneNode>` in `ImagePropertyBinding::node`;
* `Scene::RegisterShaderUserBinding` and the two image binding registrars take
  owning handles so they can downgrade from them;
* `SceneMesh::MaterialShared()` gives the parser an owning handle to slot 0
  (`Material()` is kept for the existing transient uses);
* the appliers in `SceneUserProperty.cpp` upgrade before use and skip expired
  bindings — replacing the null checks that could never catch this, since the
  pointer was non-null and the memory was gone.

I picked this over "keep the draft nodes alive in `FinalizeScene`" because
retaining prototype nodes would only make the property write land on an object
that is never rendered, and over "drop the bindings of nodes that missed the
scene" because that needs an extra graph walk and only covers nodes. Weak
handles introduce no new ownership concept and cover any future parse path that
drops a node.

### No working behaviour is lost

Every write that now gets skipped was already a write into freed memory before
this change, so it could not have reached a live object. I instrumented the
appliers to count live vs. expired bindings at apply time:

| scene | shader-uniform bindings | live | expired |
|---|---|---|---|
| `techno` (bundled) | `schemecolor` 6, `accentcolor` 2 | 0 | 8 |
| workshop 3486109050 | `newproperty11`…`16` | 5 | 0 |
| workshop 2021394523 | none applied at load | – | – |

Real bindings on live materials still apply exactly as before; only the dangling
prototype ones become inert.

That table does expose a separate, pre-existing gap worth a follow-up: `techno`'s
`schemecolor`/`accentcolor` only ever bind to prototype materials, and the
instances spawned from them by `CloneRegisteredNode` get fresh `SceneMaterial`
copies that are never registered — so those properties reach nothing either way.
That is not addressed here.

### Verification

All numbers on this machine, `techno` via the plain `SceneViewer`:

```
./build/<preset>/viewer/SceneViewer -f 30 <we>/assets \
    <we>/projects/defaultprojects/techno/techno.json
```

| build | before | after |
|---|---|---|
| ASan (`clang-relwithdebinfo` + `-fsanitize=address`) | `heap-use-after-free` in `SceneMaterial::SetShaderValue` on **6 of 6** runs | **0 of 6** |
| `clang-release`, 25 s window | died on **7 of 8** runs (`free(): invalid pointer` x5, `free(): corrupted unsorted chunks` x2) | **0 of 10** |

Other scenes checked with the patched build: workshop 2021394523 and 3486109050
both load, stay up and keep playing audio.

`ctest` on this checkout fails 70 of 405 tests, but the failing set is byte-for-byte
identical with and without the patch — they are corpus-driven tests
(`Pkgv00xx/Mdlvxx/Texb* MatchesFixture`, `TexSchema.*`, `SceneSchema.*`,
`SceneParseSmoke.EnumeratesNonEmpty`) that need a workshop corpus this machine
does not have configured. `scene_user_property_tests` passes 9/9, including two
new cases covering the expired-binding path.

### Environment

CachyOS (Arch-based), KDE Plasma 6 on Wayland, Mesa RADV, glibc 2.42, clang 22 + LLD.
