### PR TITLE
source: read Workshop subscriptions from Steam's own record

### DIFF
--- a/waywallen/CMakeLists.txt
+++ b/waywallen/CMakeLists.txt
@@ -211,6 +211,7 @@ install(FILES
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/source.lua
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/subscription.lua
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/wallpaper.lua
+    ${_OWE_PLUGIN_SRC}/wallpaper_engine/workshop.lua
     DESTINATION ${_OWE_PLUGIN_DIR}/wallpaper_engine
 )
 
@@ -230,6 +231,7 @@ set(_OWE_FILES
     wallpaper_engine/source.lua
     wallpaper_engine/subscription.lua
     wallpaper_engine/wallpaper.lua
+    wallpaper_engine/workshop.lua
     ${OWE_WESCENE_BIN}
 )
 if(BUILD_WEWEB)

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
@@ -767,4 +767,74 @@ end
 
 project.classify = original_classify
 
+-- Steam's own record of the Workshop directory: it marks the subscriptions and
+-- leaves hand-placed directories out, so they never offer an unsubscribe.
+local acf_path = steam_root .. "/steamapps/workshop/appworkshop_" .. project.WE_APPID .. ".acf"
+local hand_placed_dir = workshop .. "/2589297069"
+
+local function workshop_ctx(acf)
+    local ctx = {}
+    for key, value in pairs(source_ctx) do ctx[key] = value end
+    ctx.fs = {}
+    for key, value in pairs(source_ctx.fs) do ctx.fs[key] = value end
+    ctx.fs.exists = function(path)
+        if path == acf_path then return acf ~= nil end
+        if path == hand_placed_dir .. "/scene.pkg" then return true end
+        return source_ctx.fs.exists(path)
+    end
+    ctx.fs.read = function(path)
+        if path == acf_path then return acf end
+        return source_ctx.fs.read(path)
+    end
+    ctx.fs.list_dirs = function(path)
+        if path == workshop then return { item_dir, hand_placed_dir } end
+        return source_ctx.fs.list_dirs(path)
+    end
+    return ctx
+end
+
+local recorded_items = main.source.scan(workshop_ctx(fixtures.workshop_acf))
+equal(#recorded_items, 3, "scan item count with Steam's record")
+equal(recorded_items[1].external_id, "3765064055", "recorded subscription keeps its id")
+equal(recorded_items[2].name, "Workshop 2589297069", "hand-placed Workshop directory")
+equal(recorded_items[2].external_id, nil, "hand-placed directory must not offer unsubscribe")
+
+equal(
+    main.source.scan(workshop_ctx(fixtures.workshop_acf_truncated))[2].external_id,
+    "2589297069",
+    "truncated record keeps the previous behaviour"
+)
+equal(
+    main.source.scan(workshop_ctx(nil))[2].external_id,
+    "2589297069",
+    "missing record keeps the previous behaviour"
+)
+
+main.source.scan(workshop_ctx(fixtures.workshop_acf))
+local recorded_ctx = fake_context()
+login(recorded_ctx)
+request_count = recorded_ctx.request_count()
+equal(subscription.status(recorded_ctx, { "3765064055" })["3765064055"], "subscribed",
+    "state answered from Steam's record")
+equal(recorded_ctx.request_count(), request_count, "recorded state must not call Steam")
+
+recorded_ctx.queue(fixtures.mutation_accepted)
+equal(subscription.unsubscribe(recorded_ctx, "3765064055").accepted, true, "unsubscribe accepted")
+recorded_ctx.advance(30001)
+recorded_ctx.queue(nil, 200, fixtures.unsubscribed_page)
+request_count = recorded_ctx.request_count()
+equal(subscription.status(recorded_ctx, { "3765064055" })["3765064055"], "unsubscribed",
+    "unsubscribing here drops the item from the record")
+equal(recorded_ctx.request_count(), request_count + 1, "dropped item falls back to the page")
+
+main.source.scan(workshop_ctx(fixtures.workshop_acf))
+local forget_ctx = fake_context()
+main.actions.invoke(forget_ctx, "steam_sign_out")
+login(forget_ctx)
+forget_ctx.queue(nil, 200, fixtures.subscribed_page)
+request_count = forget_ctx.request_count()
+equal(subscription.status(forget_ctx, { "3765064055" })["3765064055"], "subscribed",
+    "record is re-read from Steam after a sign-out")
+equal(forget_ctx.request_count(), request_count + 1, "sign-out drops the recorded state")
+
 print("OWE waywallen Lua contract fixtures passed")

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/fixtures.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/fixtures.lua
@@ -111,4 +111,33 @@ return {
         },
     },
     mutation_accepted = { response = {} },
+    -- Shape Steam writes to steamapps/workshop/appworkshop_431960.acf: one
+    -- subscribed item, plus a comment and an escaped quote the reader has to
+    -- survive. The hand-placed directory 2589297069 appears in no record.
+    workshop_acf = table.concat({
+        '"AppWorkshop"',
+        "{",
+        '\t"appid"\t\t"431960"',
+        '\t// Steam writes this file itself.',
+        '\t"WorkshopItemsInstalled"',
+        "\t{",
+        '\t\t"3765064055"',
+        "\t\t{",
+        '\t\t\t"size"\t\t"4096"',
+        '\t\t\t"timeupdated"\t\t"1785290565"',
+        '\t\t\t"manifest"\t\t"1948827864188560204"',
+        "\t\t}",
+        "\t}",
+        '\t"WorkshopItemDetails"',
+        "\t{",
+        '\t\t"3765064055"',
+        "\t\t{",
+        '\t\t\t"manifest"\t\t"1948827864188560204"',
+        '\t\t\t"title"\t\t"a \\"quoted\\" title"',
+        '\t\t\t"subscribedby"\t\t"89291590"',
+        "\t\t}",
+        "\t}",
+        "}",
+    }, "\n"),
+    workshop_acf_truncated = '"AppWorkshop"\n{\n\t"WorkshopItemDetails"\n\t{\n',
 }

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/source.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/source.lua
@@ -1,4 +1,5 @@
 local project_util = import("wallpaper_engine.project")
+local workshop = import("wallpaper_engine.workshop")
 
 local M = {}
 
@@ -44,7 +45,7 @@ local function scan_container(ctx, steam_root, container, name_prefix, is_worksh
                 description = project and project.description or nil,
                 tags = (project and project.tags) or {},
                 content_rating = project and project.contentrating or nil,
-                external_id = is_workshop and id or nil,
+                external_id = is_workshop and workshop.subscription_id(id) or nil,
                 metadata = {},
             })
         end
@@ -54,13 +55,20 @@ end
 function M.scan(ctx)
     local entries = {}
 
+    local roots = {}
     for _, library in ipairs(ctx.libraries()) do
-        local steam_root = project_util.normalize_root(library)
-        local workshop = steam_root .. project_util.WORKSHOP
-        if not ctx.fs.exists(workshop) then
+        table.insert(roots, project_util.normalize_root(library))
+    end
+    -- Steam's own record decides which Workshop directories are subscriptions;
+    -- read it once per scan, before any entry asks about its id.
+    workshop.refresh(ctx, roots)
+
+    for _, steam_root in ipairs(roots) do
+        local content = steam_root .. project_util.WORKSHOP
+        if not ctx.fs.exists(content) then
             ctx.log("wallpaper_engine: no WE workshop under " .. steam_root)
         else
-            scan_container(ctx, steam_root, workshop, "Workshop ", true, entries)
+            scan_container(ctx, steam_root, content, "Workshop ", true, entries)
         end
         for _, name in ipairs(project_util.LOCAL_DIRS) do
             scan_container(

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/subscription.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/subscription.lua
@@ -1,4 +1,5 @@
 local session = import("wallpaper_engine.session")
+local workshop = import("wallpaper_engine.workshop")
 
 local M = {}
 
@@ -34,6 +35,7 @@ end
 function M.clear()
     cache = {}
     cache_generation = session.generation()
+    workshop.forget()
 end
 
 local function parse_page_state(ctx, html)
@@ -104,8 +106,13 @@ function M.status(ctx, ids)
     for _, id in ipairs(ids) do
         local key = tostring(id)
         local cached = cache[key]
+        local recorded = workshop.state(key)
         if cached and cached.expires_at > now then
             result[key] = cached.state
+        elseif recorded then
+            -- Steam already wrote this subscription down on this machine, so
+            -- the detail page would only confirm what the client knows.
+            result[key] = recorded
         else
             local ok, value = pcall(request_page, ctx, key, true)
             if not ok then
@@ -145,6 +152,7 @@ local function set_subscription(ctx, id, subscribed)
         state = subscribed and "subscribed" or "unsubscribed",
         expires_at = ctx.time.now() + MUTATION_GRACE_MS,
     }
+    workshop.mark(id, subscribed)
     return { accepted = true }
 end
 

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/workshop.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/workshop.lua
@@ -1,0 +1,177 @@
+local project_util = import("wallpaper_engine.project")
+
+local M = {}
+
+-- Steam keeps its own record of the Workshop items it downloaded for an app in
+-- `steamapps/workshop/appworkshop_<appid>.acf` (Valve KeyValues). It answers
+-- "is this item subscribed" without asking the Community site, and it is the
+-- only local signal that separates a real subscription from a directory the
+-- user copied into `content/431960` by hand.
+local ACF_REL = "/steamapps/workshop/appworkshop_" .. project_util.WE_APPID .. ".acf"
+
+-- Ids Steam recorded a subscription for, or nil while no `.acf` could be read.
+-- nil keeps every caller on the behaviour it had before this file existed.
+local subscribed = nil
+
+local ESCAPES = { n = "\n", t = "\t", r = "\r" }
+
+-- Read one quoted token and return it with the position just after it. Steam
+-- escapes with backslashes, so the token ends at the first unescaped quote.
+local function read_quoted(text, start)
+    local index = start + 1
+    local chunks = {}
+    while true do
+        local stop = text:find('["\\]', index)
+        if not stop then return nil end
+        chunks[#chunks + 1] = text:sub(index, stop - 1)
+        if text:sub(stop, stop) == '"' then
+            return table.concat(chunks), stop + 1
+        end
+        local escaped = text:sub(stop + 1, stop + 1)
+        if escaped == "" then return nil end
+        chunks[#chunks + 1] = ESCAPES[escaped] or escaped
+        index = stop + 2
+    end
+end
+
+-- Minimal KeyValues reader: nested tables of strings, tolerant of comments and
+-- unquoted tokens. Returns nil for anything it cannot make sense of, so a
+-- truncated or foreign file never reports half of the subscriptions.
+local function parse_keyvalues(text)
+    local root = {}
+    local stack = { root }
+    local pending = nil
+    local pos = 1
+    while true do
+        local at = text:find("%S", pos)
+        if not at then break end
+        local char = text:sub(at, at)
+        local token = nil
+        if char == "{" then
+            local node = {}
+            if pending ~= nil then
+                stack[#stack][pending] = node
+                pending = nil
+            end
+            stack[#stack + 1] = node
+            pos = at + 1
+        elseif char == "}" then
+            if #stack == 1 then return nil end
+            stack[#stack] = nil
+            pos = at + 1
+        elseif char == "/" and text:sub(at + 1, at + 1) == "/" then
+            local eol = text:find("\n", at, true)
+            if not eol then break end
+            pos = eol + 1
+        elseif char == '"' then
+            token, pos = read_quoted(text, at)
+            if token == nil then return nil end
+        else
+            local stop = text:find('[%s"{}]', at) or (#text + 1)
+            token = text:sub(at, stop - 1)
+            pos = stop
+        end
+        if token ~= nil then
+            if pending == nil then
+                pending = token
+            else
+                stack[#stack][pending] = token
+                pending = nil
+            end
+        end
+    end
+    if #stack ~= 1 or pending ~= nil then return nil end
+    return root
+end
+
+-- KeyValues keys are case-insensitive; Steam's casing is not part of the
+-- format's contract, so look the field up both ways.
+local function field(node, name)
+    if type(node) ~= "table" then return nil end
+    local direct = node[name]
+    if direct ~= nil then return direct end
+    local lowered = string.lower(name)
+    for key, value in pairs(node) do
+        if type(key) == "string" and string.lower(key) == lowered then return value end
+    end
+    return nil
+end
+
+-- Fold one Steam root's record into `found`. Returns whether the file could be
+-- used at all: an unreadable or detail-less file must leave the snapshot unset
+-- instead of declaring every installed item unsubscribed.
+local function fold_root(ctx, steam_root, found)
+    local path = steam_root .. ACF_REL
+    if not ctx.fs.exists(path) then return false end
+    local text = ctx.fs.read(path)
+    if not text or text == "" then
+        ctx.log("wallpaper_engine: cannot read " .. path)
+        return false
+    end
+    local ok, parsed = pcall(parse_keyvalues, text)
+    if not ok or type(parsed) ~= "table" then
+        ctx.log("wallpaper_engine: unreadable Steam Workshop state in " .. path)
+        return false
+    end
+    local details = field(field(parsed, "AppWorkshop"), "WorkshopItemDetails")
+    if type(details) ~= "table" then return false end
+    local usable = false
+    for id, entry in pairs(details) do
+        if type(entry) == "table" then
+            usable = true
+            -- `subscribedby` is the SteamID that subscribed. A directory placed
+            -- in `content/431960` by hand is in no record at all, and an item
+            -- Steam only keeps for another reason carries no id here.
+            local by = field(entry, "subscribedby")
+            if by and by ~= "" and by ~= "0" then found[tostring(id)] = true end
+        end
+    end
+    return usable
+end
+
+-- Re-read Steam's record for every registered Steam root. Called from the
+-- source scan because that is the only callback whose context carries `ctx.fs`.
+function M.refresh(ctx, roots)
+    local found, usable = {}, false
+    for _, steam_root in ipairs(roots) do
+        if fold_root(ctx, steam_root, found) then usable = true end
+    end
+    if not usable then
+        subscribed = nil
+        return
+    end
+    subscribed = found
+    local count = 0
+    for _ in pairs(found) do count = count + 1 end
+    ctx.log("wallpaper_engine: " .. count .. " Workshop subscriptions recorded by Steam")
+end
+
+-- Drop the snapshot: it describes the account the Steam client is signed in as
+-- and must not outlive a sign-out.
+function M.forget()
+    subscribed = nil
+end
+
+-- "subscribed" for items Steam recorded on this machine, nil when the local
+-- record cannot answer and the caller has to ask Steam Community instead.
+function M.state(id)
+    if subscribed and subscribed[tostring(id)] then return "subscribed" end
+    return nil
+end
+
+-- Keep the snapshot in step with subscriptions made through waywallen, so an
+-- item just unsubscribed here stops reporting the state Steam recorded before.
+function M.mark(id, is_subscribed)
+    if not subscribed then return end
+    subscribed[tostring(id)] = is_subscribed or nil
+end
+
+-- The daemon turns a non-empty `external_id` into an "Unsubscribe" button, so
+-- only items Steam recorded a subscription for may carry one. Without a
+-- snapshot the id is passed through, which is what the scan did before.
+function M.subscription_id(id)
+    if subscribed and not subscribed[tostring(id)] then return nil end
+    return id
+end
+
+return M


### PR DESCRIPTION
---

## What happens today

`wallpaper_engine/subscription.lua` resolves a subscription state by downloading
the item's Steam Community detail page and looking for
`#SubscribeItemOptionSubscribed` / `#SubscribeItemOptionAdd` in the markup, with
a browser-shaped header set (including `Accept-Language: zh`). That is one HTTP
request per item, it needs a signed-in Community session, it is cached for 60 s,
and it stops working whenever the page markup changes.

A smaller, related thing: `source.lua` gives every directory under
`content/431960` an `external_id`. The daemon reads a non-empty `external_id` on
a subscription-capable source as "this item can be unsubscribed"
(`SourceManager::supports_item_unsubscribe`), so a directory the user copied into
the Workshop folder by hand also gets an Unsubscribe button, and the request then
goes to Steam for an item the account never subscribed to.

## What this changes

Steam keeps the answer on disk. `steamapps/workshop/appworkshop_431960.acf`
(Valve KeyValues) is written by the client itself: `WorkshopItemsInstalled` is
what it downloaded, and `WorkshopItemDetails[<id>].subscribedby` is the SteamID
that subscribed to the item.

A new `wallpaper_engine/workshop.lua` reads that file and keeps the id set in
memory:

- `source.scan` refreshes it once per scan (the source context is the only one
  that carries `ctx.fs`) and hands out `external_id` only for items the record
  shows as subscribed;
- `subscription.status` answers from the record whenever it knows the item: no
  request, no Community session round trip, no dependency on page markup;
- `subscription.subscribe` / `unsubscribe` update the record in memory, so an
  item unsubscribed through waywallen stops reporting the state Steam wrote
  before the change;
- signing out drops the snapshot, since it describes the account the client is
  signed in as.

The Community path is untouched and still handles everything the record cannot
answer: an id that is not in the file, a Steam install without that file (fresh
install, Flatpak Steam, another library folder), and a file that is missing,
truncated, above the daemon's 1 MiB `ctx.fs.read` cap, or not KeyValues at all.
In each of those cases the plugin behaves exactly as before, `external_id`
included: without a usable record every Workshop directory keeps its id.

This is deliberately conservative in one direction: only "subscribed" is served
from the file. An id the record does not mention still goes to the detail page,
because absence can also mean "Steam has not written it down yet" rather than
"not subscribed".

## Why

- No network round trip and no Community session for the states the client
  already knows; it works offline.
- Independent of the Community page markup — the file's shape is what the Steam
  client itself relies on.
- One read per scan covers the whole library instead of one request per item,
  which is what a UI would need if it ever wanted the state for a whole grid.
- A directory placed in the Workshop folder by hand no longer offers an
  Unsubscribe button that cannot work.

## How it was verified

Arch (CachyOS), Lua 5.4, Steam client installed, `~/.steam/steam` registered as
the library.

- `lua tests/contract.lua <plugin root>` passes. The contract file gains fixtures
  and assertions for: a scan that sees the record (subscribed item keeps its id,
  hand-placed directory gets none), a truncated record and a missing record (both
  fall back to the previous behaviour), a status served from the record with zero
  HTTP requests, an unsubscribe that drops the item from the record so the next
  status falls back to the detail page, and a sign-out that forgets the record.
- `luac -p` on every touched file.
- Against the real file on this machine: 22 directories in `content/431960`, of
  which the record marks 20 as subscribed. That id list matches, item for item,
  what an independent reader of the same file reports. The two directories left
  without an id are a hand-placed application wallpaper (in no record at all) and
  one item whose files are still on disk after its subscription went away —
  exactly the two cases where Unsubscribe cannot work.
- The same scan against a copy of that Steam root plus a hand-made
  `content/431960/9999999999`: the two real subscriptions keep their id, the
  hand-made directory gets none. With the `.acf` removed, truncated, or replaced
  by 4 KiB of `/dev/urandom`, all three directories keep their ids and the scan
  logs a single line about the unusable record.
- Parser against the other `appworkshop_*.acf` files present here (241100 with 56
  subscriptions, 1771300, 1812620, 475150): 0.0-1.0 ms each. A synthetic 0.7 MiB
  record with 12000 items parses in 43 ms.

Happy to split the `external_id` part into its own commit, or drop it, if you
would rather fix the Unsubscribe button on the daemon side.
