### PR TITLE
source: report the size Steam recorded for a Workshop item

### DIFF
--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
@@ -771,6 +771,7 @@ project.classify = original_classify
 -- leaves hand-placed directories out, so they never offer an unsubscribe.
 local acf_path = steam_root .. "/steamapps/workshop/appworkshop_" .. project.WE_APPID .. ".acf"
 local hand_placed_dir = workshop .. "/2589297069"
+local unmeasured_dir = workshop .. "/3765064056"
 
 local function workshop_ctx(acf)
     local ctx = {}
@@ -780,6 +781,7 @@ local function workshop_ctx(acf)
     ctx.fs.exists = function(path)
         if path == acf_path then return acf ~= nil end
         if path == hand_placed_dir .. "/scene.pkg" then return true end
+        if path == unmeasured_dir .. "/scene.pkg" then return true end
         return source_ctx.fs.exists(path)
     end
     ctx.fs.read = function(path)
@@ -787,28 +789,28 @@ local function workshop_ctx(acf)
         return source_ctx.fs.read(path)
     end
     ctx.fs.list_dirs = function(path)
-        if path == workshop then return { item_dir, hand_placed_dir } end
+        if path == workshop then return { item_dir, hand_placed_dir, unmeasured_dir } end
         return source_ctx.fs.list_dirs(path)
     end
     return ctx
 end
 
 local recorded_items = main.source.scan(workshop_ctx(fixtures.workshop_acf))
-equal(#recorded_items, 3, "scan item count with Steam's record")
+equal(#recorded_items, 4, "scan item count with Steam's record")
 equal(recorded_items[1].external_id, "3765064055", "recorded subscription keeps its id")
+equal(recorded_items[1].size, 4096, "recorded item reports the size Steam measured")
 equal(recorded_items[2].name, "Workshop 2589297069", "hand-placed Workshop directory")
 equal(recorded_items[2].external_id, nil, "hand-placed directory must not offer unsubscribe")
+equal(recorded_items[2].size, nil, "hand-placed directory was never measured by Steam")
+equal(recorded_items[3].size, nil, "record without a size leaves the item unmeasured")
+equal(recorded_items[4].size, nil, "local project is outside Steam's Workshop record")
 
-equal(
-    main.source.scan(workshop_ctx(fixtures.workshop_acf_truncated))[2].external_id,
-    "2589297069",
-    "truncated record keeps the previous behaviour"
-)
-equal(
-    main.source.scan(workshop_ctx(nil))[2].external_id,
-    "2589297069",
-    "missing record keeps the previous behaviour"
-)
+local truncated_items = main.source.scan(workshop_ctx(fixtures.workshop_acf_truncated))
+equal(truncated_items[2].external_id, "2589297069", "truncated record keeps the previous behaviour")
+equal(truncated_items[1].size, nil, "truncated record measures nothing")
+local unrecorded_items = main.source.scan(workshop_ctx(nil))
+equal(unrecorded_items[2].external_id, "2589297069", "missing record keeps the previous behaviour")
+equal(unrecorded_items[1].size, nil, "missing record measures nothing")
 
 main.source.scan(workshop_ctx(fixtures.workshop_acf))
 local recorded_ctx = fake_context()

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/fixtures.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/fixtures.lua
@@ -112,8 +112,9 @@ return {
     },
     mutation_accepted = { response = {} },
     -- Shape Steam writes to steamapps/workshop/appworkshop_431960.acf: one
-    -- subscribed item, plus a comment and an escaped quote the reader has to
-    -- survive. The hand-placed directory 2589297069 appears in no record.
+    -- subscribed item, one subscribed item the client recorded without a size,
+    -- plus a comment and an escaped quote the reader has to survive. The
+    -- hand-placed directory 2589297069 appears in no record.
     workshop_acf = table.concat({
         '"AppWorkshop"',
         "{",
@@ -127,6 +128,11 @@ return {
         '\t\t\t"timeupdated"\t\t"1785290565"',
         '\t\t\t"manifest"\t\t"1948827864188560204"',
         "\t\t}",
+        '\t\t"3765064056"',
+        "\t\t{",
+        '\t\t\t"timeupdated"\t\t"1785290566"',
+        '\t\t\t"manifest"\t\t"1948827864188560205"',
+        "\t\t}",
         "\t}",
         '\t"WorkshopItemDetails"',
         "\t{",
@@ -134,6 +140,11 @@ return {
         "\t\t{",
         '\t\t\t"manifest"\t\t"1948827864188560204"',
         '\t\t\t"title"\t\t"a \\"quoted\\" title"',
+        '\t\t\t"subscribedby"\t\t"89291590"',
+        "\t\t}",
+        '\t\t"3765064056"',
+        "\t\t{",
+        '\t\t\t"manifest"\t\t"1948827864188560205"',
         '\t\t\t"subscribedby"\t\t"89291590"',
         "\t\t}",
         "\t}",

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/source.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/source.lua
@@ -46,6 +46,10 @@ local function scan_container(ctx, steam_root, container, name_prefix, is_worksh
                 tags = (project and project.tags) or {},
                 content_rating = project and project.contentrating or nil,
                 external_id = is_workshop and workshop.subscription_id(id) or nil,
+                -- Steam measured the item when it unpacked it; without that the
+                -- daemon stats `resource` alone and calls a web wallpaper's
+                -- directory inode the size of the wallpaper.
+                size = is_workshop and workshop.size(id) or nil,
                 metadata = {},
             })
         end

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/workshop.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/workshop.lua
@@ -13,6 +13,10 @@ local ACF_REL = "/steamapps/workshop/appworkshop_" .. project_util.WE_APPID .. "
 -- nil keeps every caller on the behaviour it had before this file existed.
 local subscribed = nil
 
+-- Bytes on disk per id, as Steam wrote them down when it unpacked the item.
+-- A missing id means "the record does not say", never "empty".
+local sizes = {}
+
 local ESCAPES = { n = "\n", t = "\t", r = "\r" }
 
 -- Read one quoted token and return it with the position just after it. Steam
@@ -97,10 +101,10 @@ local function field(node, name)
     return nil
 end
 
--- Fold one Steam root's record into `found`. Returns whether the file could be
--- used at all: an unreadable or detail-less file must leave the snapshot unset
--- instead of declaring every installed item unsubscribed.
-local function fold_root(ctx, steam_root, found)
+-- Fold one Steam root's record into `found` and `found_sizes`. Returns whether
+-- the file could be used at all: an unreadable or detail-less file must leave
+-- the snapshot unset instead of declaring every installed item unsubscribed.
+local function fold_root(ctx, steam_root, found, found_sizes)
     local path = steam_root .. ACF_REL
     if not ctx.fs.exists(path) then return false end
     local text = ctx.fs.read(path)
@@ -113,7 +117,21 @@ local function fold_root(ctx, steam_root, found)
         ctx.log("wallpaper_engine: unreadable Steam Workshop state in " .. path)
         return false
     end
-    local details = field(field(parsed, "AppWorkshop"), "WorkshopItemDetails")
+    local app = field(parsed, "AppWorkshop")
+    -- `WorkshopItemsInstalled` is the download bookkeeping: for every item the
+    -- client unpacked it holds the byte size of the unpacked directory, so the
+    -- scan gets the size on disk without walking the tree. A directory copied
+    -- into `content/431960` by hand is in no section and stays unmeasured.
+    local downloaded = field(app, "WorkshopItemsInstalled")
+    if type(downloaded) == "table" then
+        for id, entry in pairs(downloaded) do
+            local size = tonumber(field(entry, "size"))
+            if size and size > 0 then
+                found_sizes[tostring(id)] = math.floor(size)
+            end
+        end
+    end
+    local details = field(app, "WorkshopItemDetails")
     if type(details) ~= "table" then return false end
     local usable = false
     for id, entry in pairs(details) do
@@ -132,10 +150,13 @@ end
 -- Re-read Steam's record for every registered Steam root. Called from the
 -- source scan because that is the only callback whose context carries `ctx.fs`.
 function M.refresh(ctx, roots)
-    local found, usable = {}, false
+    local found, found_sizes, usable = {}, {}, false
     for _, steam_root in ipairs(roots) do
-        if fold_root(ctx, steam_root, found) then usable = true end
+        if fold_root(ctx, steam_root, found, found_sizes) then usable = true end
     end
+    -- Sizes stand on their own: they describe the directories on this disk, so
+    -- a record without usable details still gets to report the ones it listed.
+    sizes = found_sizes
     if not usable then
         subscribed = nil
         return
@@ -164,6 +185,13 @@ end
 function M.mark(id, is_subscribed)
     if not subscribed then return end
     subscribed[tostring(id)] = is_subscribed or nil
+end
+
+-- Size on disk in bytes for an item Steam downloaded, nil for everything the
+-- record does not cover. The daemon leaves a nil size to its own probing, and
+-- the client hides the "Size" row while nothing knows the answer.
+function M.size(id)
+    return sizes[tostring(id)]
 end
 
 -- The daemon turns a non-empty `external_id` into an "Unsubscribe" button, so


### PR DESCRIPTION
### What it does

The source scan now hands the daemon a `size` for Workshop items, taken from Steam's own record of the Workshop directory.

Until now the scan emitted no size, so the daemon's tier-1 stat filled the field in from `resource` alone. For a scene that is the size of `scene.pkg`; for a web wallpaper `resource` *is* the item directory, so the field ended up holding the directory inode. In my library the detail panel showed `76 B`, `128 B` and `170 B` for web items that occupy 1.1 MB, 621.3 MB and 876.5 MB on disk.

### Where the data comes from

`steamapps/workshop/appworkshop_431960.acf` — the same file #84 already reads for subscriptions. Next to `WorkshopItemDetails` it carries a `WorkshopItemsInstalled` section, one entry per item the client unpacked:

```
"WorkshopItemsInstalled"
{
        "1824745852"
        {
                "size"          "449750456"
                "timeupdated"   "1564914545"
                "manifest"      "7363103989764156665"
        }
        ...
}
```

That is the size on disk, measured by the client, so nothing has to walk the item's directory tree. `wallpaper_engine/workshop.lua` folds the section during the same `refresh()` pass it already does for subscriptions — no second `.acf` reader — and `workshop.size(id)` answers the scan.

### When the record says nothing

`size` is simply absent from the entry, which is what the scan emitted before this change, and the daemon's own probing is left exactly where it was. That covers:

* a client old enough to have recorded no `size` for an item;
* a directory copied into `content/431960` by hand — it appears in no section of the record, the same reason #84 gives it no `external_id`;
* a missing, empty, truncated or otherwise unreadable file.

Sizes are folded independently of the subscription snapshot: a record whose `WorkshopItemDetails` is unusable still measures the items `WorkshopItemsInstalled` listed, and still leaves subscription state to the previous code path.

One interaction worth naming: for a *newly* scanned item the row is created with `stat_at` NULL, so `list_items_needing_stat` still picks it up once and overwrites the size with the `resource` stat. The next scan's `COALESCE(excluded.size, size)` upsert puts the recorded size back, so the steady state is the value above — but the very first pass after an item appears can still show the old number.

### How it was checked

* `lua tests/contract.lua .` — extended with the new assertions; it fails without the `source.lua` change.
* Against the real `appworkshop_431960.acf` on this machine: all 21 recorded sizes matched `du -sb` on the item directory, byte for byte.
* Driven through the daemon with the plugin installed: the `size` column for every Workshop item switched to the recorded value, and the web items above went from `76 B` / `128 B` / `170 B` to 1.1 MB / 621.3 MB / 876.5 MB.
* Failure paths, against copies of the real Steam root with the record replaced: truncated, random bytes, zero-length, and absent. Each one scans the same 25 wallpapers, reports no size for any of them, logs and moves on. A record with `WorkshopItemsInstalled` intact but `WorkshopItemDetails` cut off measures the items and leaves subscriptions alone.
* A directory placed in `content/431960` by hand: no size and no `external_id`, as intended.
