### PR TITLE
source: name Workshop items after their author

### DIFF
--- a/waywallen/CMakeLists.txt
+++ b/waywallen/CMakeLists.txt
@@ -206,6 +206,7 @@ install(FILES
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/auth.lua
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/discover.lua
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/map.lua
+    ${_OWE_PLUGIN_SRC}/wallpaper_engine/profile.lua
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/project.lua
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/session.lua
     ${_OWE_PLUGIN_SRC}/wallpaper_engine/source.lua
@@ -226,6 +227,7 @@ set(_OWE_FILES
     wallpaper_engine/auth.lua
     wallpaper_engine/discover.lua
     wallpaper_engine/map.lua
+    wallpaper_engine/profile.lua
     wallpaper_engine/project.lua
     wallpaper_engine/session.lua
     wallpaper_engine/source.lua

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
@@ -563,7 +563,9 @@ equal(transient_ok, false, "finalization HTTP failure")
 
 local discover_ctx = fake_context()
 login(discover_ctx)
+local before_search = discover_ctx.request_count()
 discover_ctx.queue(fixtures.query_files)
+discover_ctx.queue(nil, 200, fixtures.profile_xml)
 local search = main.discover.search(discover_ctx, {
     query = "fixture",
     sort = "trend_week",
@@ -573,10 +575,22 @@ local search = main.discover.search(discover_ctx, {
 equal(#search.items, 1, "search item count")
 equal(search.items[1].id, "3765064055", "search item id")
 equal(search.items[1].wp_type, "scene", "search item type")
-request = discover_ctx.last_request()
+equal(search.items[1].author, "Fixture & Author", "search item author")
+request = discover_ctx.request_at(before_search + 1)
 equal(request.method, "GET", "QueryFiles method")
 equal(request.query_data.access_token, "header.community.signature", "QueryFiles Community token")
 equal(request.query_data.appid, "431960", "QueryFiles appid")
+equal(
+    discover_ctx.request_at(before_search + 2).url,
+    "https://steamcommunity.com/profiles/76561198000000001/?xml=1",
+    "creator profile XML URL"
+)
+-- A name already looked up costs nothing: a second search that asked Steam
+-- again would run out of queued responses and fail here.
+discover_ctx.queue(fixtures.query_files)
+local cached_search = main.discover.search(discover_ctx, { sort = "trend_week", page = 1 })
+equal(cached_search.items[1].author, "Fixture & Author", "cached author reused")
+equal(discover_ctx.queued_count(), 0, "cached author must not be looked up again")
 local request_count = discover_ctx.request_count()
 local details = main.discover.details(discover_ctx, "3765064055")
 equal(details.size, "4096", "cached details size")
@@ -588,6 +602,38 @@ equal(
 equal(discover_ctx.request_count(), request_count, "search metadata must be reused")
 discover_ctx.queue(fixtures.file_details)
 equal(main.discover.details(discover_ctx, "fallback").size, "8192", "fallback details")
+
+local profile = import("wallpaper_engine.profile")
+local profile_ctx = fake_context()
+
+-- Steam answering that it has no such profile is an answer: remember it, so the
+-- same dead creator is not looked up once per page for the rest of the session.
+profile_ctx.queue(nil, 200, fixtures.profile_missing_xml)
+equal(profile.names(profile_ctx, { "76561198000000002" })["76561198000000002"], nil,
+    "missing profile yields no author")
+local missing_requests = profile_ctx.request_count()
+profile.names(profile_ctx, { "76561198000000002" })
+equal(profile_ctx.request_count(), missing_requests, "missing profile must not be asked twice")
+
+-- Anything else Steam sends back is not an answer, so nothing is remembered and
+-- the grid keeps the empty author it had before.
+profile_ctx.queue(nil, 200, "<html><body>Steam is having a moment</body></html>")
+equal(next(profile.names(profile_ctx, { "76561198000000003" })), nil,
+    "unparsable profile yields no author")
+
+-- Steam being unreachable costs a search a couple of failed requests, not one
+-- per creator, and is forgotten so a later search can try again.
+profile_ctx.queue(nil, 503)
+profile_ctx.queue(nil, 503)
+equal(next(profile.names(profile_ctx, {
+    "76561198000000004",
+    "76561198000000005",
+    "76561198000000006",
+})), nil, "unreachable Steam yields no authors")
+equal(profile_ctx.queued_count(), 0, "failing lookups stop at the failure limit")
+profile_ctx.queue(nil, 200, fixtures.profile_xml)
+equal(profile.names(profile_ctx, { "76561198000000004" })["76561198000000004"],
+    "Fixture & Author", "a failed lookup is retried later")
 
 local subscription_ctx = fake_context()
 login(subscription_ctx)

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/fixtures.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/fixtures.lua
@@ -77,12 +77,25 @@ return {
         .. '<div id="SubscribeItemOptionAdd" '
         .. 'class="subscribeOption add selected">Subscribe</div>',
     signed_out_page = '<a href="https://steamcommunity.com/login">Sign In</a>',
+    -- Shape of steamcommunity.com/profiles/<id>/?xml=1: the persona name is
+    -- wrapped in CDATA, and a group further down repeats tags the reader must
+    -- not confuse with the profile's own.
+    profile_xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><profile>'
+        .. "<steamID64>76561198000000001</steamID64>"
+        .. "<steamID><![CDATA[Fixture &amp; Author]]></steamID>"
+        .. "<privacyState>public</privacyState>"
+        .. "<groups><group><groupName><![CDATA[Fixture group]]></groupName></group></groups>"
+        .. "</profile>",
+    profile_missing_xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        .. "<response><error><![CDATA[The specified profile could not be found.]]></error>"
+        .. "</response>",
     query_files = {
         response = {
             total = 1,
             publishedfiledetails = {
                 {
                     publishedfileid = "3765064055",
+                    creator = "76561198000000001",
                     title = "Fixture wallpaper",
                     preview_url = "https://example.invalid/preview.jpg",
                     short_description = "Fixture description",

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/discover.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/discover.lua
@@ -1,15 +1,24 @@
 local api = import("wallpaper_engine.api")
 local map = import("wallpaper_engine.map")
+local profile = import("wallpaper_engine.profile")
 
 local M = {}
 local cached_details = {}
 
 function M.search(ctx, params)
     local result = api.search(ctx, params)
+    -- Workshop items carry their creator's steamid64, never the name behind it;
+    -- resolve the ids in page order so the top of the grid is named first when
+    -- the lookup cannot cover all of them.
+    local creators = {}
+    for _, item in ipairs(result.items) do
+        creators[#creators + 1] = tostring(item.creator or "")
+    end
+    local authors = profile.names(ctx, creators)
     local items = {}
     for _, item in ipairs(result.items) do
         cached_details[tostring(item.publishedfileid or "")] = item
-        table.insert(items, map.search_item(item))
+        table.insert(items, map.search_item(item, authors))
     end
     local page = params.page or 1
     return {

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/map.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/map.lua
@@ -31,12 +31,15 @@ local function preview_url(item)
     return first.url or ""
 end
 
-function M.search_item(item)
+-- `authors` maps a creator's steamid64 to a persona name. A creator missing
+-- from it keeps the empty author the Workshop grid has always shown.
+function M.search_item(item, authors)
+    local creator = tostring(item.creator or "")
     return {
         id = tostring(item.publishedfileid or ""),
         title = item.title or "",
         preview_url = preview_url(item),
-        author = "",
+        author = authors and authors[creator] or "",
         wp_type = wp_type(item),
     }
 end

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/profile.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/profile.lua
@@ -1,0 +1,113 @@
+local M = {}
+
+-- Steam hands persona names out through ISteamUser/GetPlayerSummaries, which
+-- takes a Web API publisher key. waywallen ships no key and must not ask a user
+-- for one, so the names come from the place that serves them without any: a
+-- Community profile asked for its XML representation.
+local PROFILE = "https://steamcommunity.com/profiles/"
+local PROFILE_QUERY = "/?xml=1"
+local PROFILE_HEADERS = {
+    Accept = "application/xml,text/xml,*/*;q=0.8",
+    ["Sec-Fetch-Dest"] = "empty",
+    ["Sec-Fetch-Mode"] = "cors",
+    ["Sec-Fetch-Site"] = "same-origin",
+}
+local REQUEST_TIMEOUT = 10
+
+-- One name is one round trip to Steam and a Workshop page carries up to thirty
+-- distinct creators, so resolving a cold page in full would hold the grid for
+-- half a minute. Spend at most this much on the names a page still needs and
+-- leave the rest to the next search: the cache is what fills the grid in, no
+-- single call has to.
+local BUDGET_MS = 4000
+
+-- Steam being unreachable has to cost one search a couple of failed requests,
+-- not one per creator on the page.
+local FAILURE_LIMIT = 2
+
+-- steamid64 -> persona name, or false once Steam has answered without one.
+-- Persona names are public and account-independent, so this outlives a sign-out.
+local names = {}
+
+local ENTITIES = { amp = "&", lt = "<", gt = ">", quot = '"', apos = "'" }
+
+local function decode_entities(text)
+    return (text:gsub("&(#?%w+);", function(name)
+        if name:sub(1, 1) ~= "#" then return ENTITIES[name] end
+        local hex = name:match("^#[xX](%x+)$")
+        local code = hex and tonumber(hex, 16) or tonumber(name:sub(2))
+        if not code or code < 0 or code > 0x10FFFF then return nil end
+        local ok, encoded = pcall(utf8.char, code)
+        return ok and encoded or nil
+    end))
+end
+
+-- The reply is XML, and the plugin runtime only offers an HTML parser. HTML
+-- parsing turns the CDATA section Steam wraps every name in into a comment and
+-- drops the name with it, so read the one element that is wanted out of a
+-- document whose shape is fixed rather than pull in an XML parser for it.
+-- `steamID` is the persona name and appears once; a group's name is `groupName`.
+local function persona_name(xml)
+    if xml:find("<error>", 1, true) then return nil end
+    local raw = xml:match("<steamID>(.-)</steamID>")
+    if not raw then return nil end
+    local text = raw:match("^<!%[CDATA%[(.-)%]%]>$") or raw
+    text = decode_entities(text):match("^%s*(.-)%s*$")
+    if text == "" then return nil end
+    return text
+end
+
+local function fetch(ctx, steamid)
+    local response = ctx.http
+        :get(PROFILE .. ctx.url.encode_component(steamid) .. PROFILE_QUERY)
+        :headers(PROFILE_HEADERS)
+        :timeout(REQUEST_TIMEOUT)
+        :send()
+    if not response:ok() then
+        error("steam profile http " .. tostring(response:status()))
+    end
+    return persona_name(response:text() or "")
+end
+
+-- Persona names for the given steamid64s, in as far as they are already known
+-- or can be looked up inside the budget. Ids left out of the answer keep the
+-- empty author the Workshop grid showed before, which is also what a profile
+-- that is gone, private or unreachable falls back to.
+function M.names(ctx, ids)
+    local resolved = {}
+    local pending = {}
+    local seen = {}
+    for _, id in ipairs(ids) do
+        local key = tostring(id or "")
+        if key ~= "" and not seen[key] then
+            seen[key] = true
+            local cached = names[key]
+            if cached then
+                resolved[key] = cached
+            elseif cached == nil then
+                pending[#pending + 1] = key
+            end
+        end
+    end
+    if #pending == 0 then return resolved end
+
+    local deadline = ctx.time.now() + BUDGET_MS
+    local failures = 0
+    for _, key in ipairs(pending) do
+        if failures >= FAILURE_LIMIT or ctx.time.now() >= deadline then break end
+        local ok, name = pcall(fetch, ctx, key)
+        if not ok then
+            -- Nothing was learned about this creator, so do not remember an
+            -- answer: the next search asks again.
+            failures = failures + 1
+            ctx.log("wallpaper_engine: Steam profile " .. key .. " unavailable")
+        else
+            failures = 0
+            names[key] = name or false
+            if name then resolved[key] = name end
+        end
+    end
+    return resolved
+end
+
+return M


### PR DESCRIPTION
Workshop items have always been sent to waywallen with an empty `author`, so the `by %1` line in the detail panel and the `Author` row in the info page never had anything to show. This fills them in.

## Why without a Web API key

The name behind a `creator` steamid64 is only served by `ISteamUser/GetPlayerSummaries`, which needs a Web API publisher key. This plugin cannot ship one and should not ask users for one. A Community profile asked for its XML representation (`https://steamcommunity.com/profiles/<steamid64>/?xml=1`) carries the same persona name, needs no key, and works signed in or not.

No new Workshop request is added: `QueryFiles` already returns each item's `creator`, so only the id has to be turned into a name.

## Cost, and why searches stay responsive

One name is one round trip to Steam, and a page of 30 items holds 15-28 distinct creators. Resolving a cold page in full measured out at ~10-25 s, which is not something a grid load can absorb, and Steam has no keyless endpoint that resolves several ids at once (`ajaxresolveusers` answers for one id and returns `null` for a list).

So a search spends at most 4 s on names it does not know yet and leaves the rest to the next one. The per-session cache is what fills the grid in; browsing converges within a couple of searches, and a warm search costs nothing extra. Since the name is only rendered in the detail panel and never on the grid card, a page that is not fully resolved yet is not visible as a gap.

Measured on the same page, cold process:

| search | named | elapsed |
|---|---|---|
| 1 | 15/30 | 4.9 s |
| 2 | 29/30 | 5.1 s |
| 3 | 30/30 | 1.2 s |
| 4 | 30/30 | 0.7 s |

Baseline (no lookups pending) is 0.7 s, i.e. unchanged from before this patch.

## When it fails

Anything that is not an answer - Steam unreachable, a timeout, a body that does not parse - is not remembered and leaves the item with the empty author it had before. Two failures in a row end the batch, so an outage costs a search two requests instead of one per creator. What Steam *has* answered is remembered, including "this profile has no name to give", so a deleted, private or nameless creator is not looked up once per page for the rest of the session.

## Parsing

The reply is XML and the plugin runtime only offers an HTML parser, which turns the CDATA section Steam wraps every name in into a comment and loses the name with it. The document has a fixed, flat shape, so the one element that is wanted is read out of it directly rather than taking on an XML parser for a single field. Entity decoding and the CDATA wrapper are handled; `steamID` is the persona name and appears once (a group's name is `groupName`).

## How it was tested

* `lua tests/contract.lua .` - extended with the author path: a search fills the name, a cached name costs no request, a profile Steam cannot find is remembered as nameless and not asked twice, an unparsable body yields no author, and repeated HTTP failures stop at the limit and are retried on a later search.
* The parser was run against live profile XML from real Workshop creators, including CJK persona names, a deleted profile (`<error>` document) and an unreachable id.
* End to end against a real waywallen daemon on a throwaway `XDG_DATA_HOME`, driving `RemoteSearch` over the control plane with a real signed-in Steam session: 30/30 items named, e.g. `[Arthesian] Customizable Module Visualizer`, `[VISUALDON] Floating In Space By VISUALDON`, `[大污师！] 囍`.
* Failure path on the same setup with the profile host pointed at an unresolvable name: search still returned all 30 items in 1.0 s with an empty error and empty authors, two failed requests per search, nothing logged beyond the plugin's own notice.
* `scripts/format.sh --check` passes.

## Not included

Author avatars. `RemoteItem` in waywallen's `control.proto` has no field for one and nothing in the UI draws it, so it cannot be delivered from the plugin side; that belongs in a waywallen change first. Same for a "more from this author" link.
