### PR TITLE
vulkan: rebuild render graph when media textures cannot refresh in place

### DIFF
--- a/src/Scene/VulkanRender/Pass/CustomShaderPass.cpp
+++ b/src/Scene/VulkanRender/Pass/CustomShaderPass.cpp
@@ -498,8 +498,17 @@ std::vector<PassTextureRequestDiagnostic> CustomShaderPass::textureRequestDiagno
 MaterialTextureBindingRefresh
 CustomShaderPass::refreshMaterialTextureBindings(const RenderSceneSnapshot& render_scene) {
     MaterialTextureBindingRefresh result;
-    if (m_desc.material_override) return result;
-    if (m_desc.node.is_none() || (*m_desc.node)->Mesh() == nullptr) return result;
+    if (m_desc.material_override) {
+        // This pass renders a build-time clone of the material (effect chain);
+        // an in-place refresh cannot see the mutated base material (e.g. a new
+        // $mediaThumbnail), so rebuild the graph to regenerate the override.
+        // Only reached when the caller matched this pass to a changed material.
+        result.requires_graph_rebuild = true;
+        return result;
+    }
+    if (m_desc.node.is_none() || (*m_desc.node)->Mesh() == nullptr) {
+        return result;
+    }
 
     auto&             mesh          = *(*m_desc.node)->Mesh();
     const std::size_t submesh_index = m_desc.submesh_index.to_primitive();
@@ -531,6 +540,19 @@ CustomShaderPass::refreshMaterialTextureBindings(const RenderSceneSnapshot& rend
         if (old.name == rstd::cppstd::as_str(next).unwrap() &&
             ! IsLocalSceneMaterialTextureDependency(next_dep))
             continue;
+
+        if (! next.empty()) {
+            // A slot that was empty at graph build (e.g. $mediaThumbnail before
+            // any track played) has no texture use slot or graph read edge, so
+            // an in-place refresh cannot bind the new image. Likewise a texture
+            // registered after the snapshot was taken (runtime media art) is
+            // unknown to this snapshot. Both need a graph rebuild to bind.
+            if (old.use.is_none() ||
+                render_scene.textureDescId(rstd::cppstd::as_str(next).unwrap()).is_none()) {
+                result.requires_graph_rebuild = true;
+                return result;
+            }
+        }
 
         TextureBindingRequest binding;
         if (! next.empty()) {


### PR DESCRIPTION
Fixes #101. Likely also addresses the thumbnail half of #90.

Runtime `$mediaThumbnail` / `$mediaPreviousThumbnail` updates never became visible: the snapshot reached the renderer, `ApplyTexture` updated the materials, dirty events fired and the passes matched — but `CustomShaderPass::refreshMaterialTextureBindings` silently bailed for every affected pass, so the decoded image was never bound.

### The three silent bail-outs

1. **`material_override` passes** (any effect-wrapped object — e.g. a cover behind a perspective effect) render a build-time clone of the material. An in-place refresh cannot see the mutated base material, and the code skipped these passes entirely.
2. **Slots empty at graph build** have no texture use slot or graph read edge — `binding.use = old.use` reuses nothing, so the new request has nowhere to land.
3. **Textures registered after the `RenderSceneSnapshot` was taken** (all runtime media art) miss `textureDescId()`, yielding an Imported request without a source.

### The fix

Request `requires_graph_rebuild` in those cases. The caller already handles that flag with `rebuildRenderGraph(KeepSceneTextures)`, which re-extracts the snapshot and rebuilds override materials and bindings from current scene state — after which the media texture binds correctly.

The rebuild only triggers when a *matched* pass's material actually changed, so the cost is one graph rebuild per track change (same order as a user-property change), not per frame. A future optimization could refresh override passes in place by re-deriving the override from the base material, but correctness first.

### Verified

On "Vinyl Record Player" (Workshop 2873513347, `usertextures` system binding behind a perspective effect), with an instrumented build tracing each stage: before — apply ✓ / events ✓ / items matched ✓ / all passes skipped ✗, cover permanently fallback; after — cover displays published art and follows track changes. Reproduced and verified on waywallen 0.3.3 / plugin 0.2.3 / Plasma 6.7.4 Wayland / Intel Iris Xe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQ29toRL8iv3RjVBcLobF4