### PR TITLE
source: read wallpaper property titles in the user's language

### DIFF
--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/tests/contract.lua
@@ -985,4 +985,61 @@ equal(subscription.status(forget_ctx, { "3765064055" })["3765064055"], "subscrib
     "record is re-read from Steam after a sign-out")
 equal(forget_ctx.request_count(), request_count + 1, "sign-out drops the recorded state")
 
+-- Wallpaper property titles are keys into Wallpaper Engine's own locale
+-- tables. The plugin used to read ui_en-us.json only, so a Russian user read
+-- English property names next to a Russian UI. `$LANG` now picks the file,
+-- with en-us left behind it because the translated files trail en-us by a few
+-- dozen keys.
+local locale_dir = steam_root .. "/steamapps/common/wallpaper_engine/locale/"
+local locale_files = {
+    ["ui_en-us.json"] = { ui_prop_speed = "Speed", ui_prop_only_en = "English only" },
+    ["ui_ru-ru.json"] = { ui_prop_speed = "Скорость" },
+}
+local locale_ctx = {
+    env = function(name) return name == "LANG" and "ru_RU.UTF-8" or nil end,
+    config = { get = function() return nil end },
+    fs = {
+        exists = function(path)
+            local name = path:match("([^/]+)$")
+            if path:sub(1, #locale_dir) == locale_dir then
+                return locale_files[name] ~= nil
+            end
+            return path == item_dir .. "/project.json"
+        end,
+        read = function(path)
+            local name = path:match("([^/]+)$")
+            if path:sub(1, #locale_dir) == locale_dir and locale_files[name] then
+                return "locale:" .. name
+            end
+            if path == item_dir .. "/project.json" then return "locale-project" end
+            return nil
+        end,
+    },
+    json = {
+        parse = function(value)
+            local name = value:match("^locale:(.+)$")
+            if name then return locale_files[name] end
+            if value == "locale-project" then
+                return { general = { properties = {
+                    speed = { text = "ui_prop_speed", type = "slider", value = 1 },
+                    only_en = { text = "ui_prop_only_en", type = "bool", value = true },
+                    unknown = { text = "ui_prop_absent", type = "bool", value = true },
+                } } }
+            end
+            return nil
+        end,
+        encode = function(value) return value end,
+    },
+}
+local locale_props = main.wallpaper.properties(
+    { wp_type = "scene", resource = item_dir .. "/scene.pkg", library_root = steam_root },
+    locale_ctx
+)
+truthy(locale_props.speed.text:find("Скорость", 1, true),
+    "property title takes the translation for the user's language")
+truthy(locale_props.only_en.text:find("English only", 1, true),
+    "key missing from the translated file falls back to en-us")
+truthy(locale_props.unknown.text:find("ui_prop_absent", 1, true),
+    "key in neither file is left alone")
+
 print("OWE waywallen Lua contract fixtures passed")

--- a/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/wallpaper.lua
+++ b/waywallen/plugins/org.waywallen.open-wallpaper-engine/wallpaper_engine/wallpaper.lua
@@ -3,32 +3,121 @@ local project_util = import("wallpaper_engine.project")
 local M = {}
 
 local _locale_cache = {}
+local _tag_cache = nil
 
-local LOCALE_REL = "/steamapps/common/wallpaper_engine/locale/ui_en-us.json"
+local LOCALE_DIR = "/steamapps/common/wallpaper_engine/locale/"
+local FALLBACK_TAG = "en-us"
 local PROPERTY_TITLE_PREFIX = "<style>\n  img { max-width: 100%; }\n  </style>\n"
 
-local function load_locale(ctx, library_root)
-    if library_root == nil or library_root == "" then return nil end
-    if _locale_cache[library_root] ~= nil then
-        return _locale_cache[library_root] or nil
+-- Wallpaper Engine names its locale files after its own language list, not
+-- after the POSIX locale, so the tag cannot always be derived from `$LANG`.
+-- Only the cases `<lang>-<region>` and `<lang>-<lang>` miss are listed here.
+local LOCALE_ALIASES = {
+    ["zh-cn"] = "zh-chs", ["zh-sg"] = "zh-chs", ["zh-hans"] = "zh-chs",
+    ["zh-tw"] = "zh-cht", ["zh-hk"] = "zh-cht", ["zh-mo"] = "zh-cht",
+    ["zh-hant"] = "zh-cht",
+    ar = "ar-sa", be = "be-by", cs = "cs-cz", da = "da-dk", el = "el-gr",
+    en = "en-us", eu = "eu-es", fa = "fa-ir", he = "he-il", ja = "ja-jp",
+    ko = "ko-kr", nb = "nb-no", no = "nb-no", pt = "pt-pt", sl = "sl-si",
+    sv = "sv-se", uk = "uk-ua", vi = "vi-vn", zh = "zh-chs",
+}
+
+-- "ru_RU.UTF-8@euro" / "ru-RU" -> "ru", "ru". Region may come back empty.
+local function split_posix_locale(value)
+    local body = string.match(value, "^([^.@]+)") or value
+    body = string.gsub(body, "-", "_")
+    local lang, region = string.match(body, "^(%a+)_(%w+)$")
+    if not lang then
+        lang = string.match(body, "^(%a+)$")
     end
-    local path = library_root .. LOCALE_REL
-    if not ctx.fs.exists(path) then
-        _locale_cache[library_root] = false
-        return nil
+    if not lang then return nil, nil end
+    return string.lower(lang), region and string.lower(region) or nil
+end
+
+-- The language the user reads, as a Wallpaper Engine locale tag. An explicit
+-- `wallpaper_engine_locale` setting wins; otherwise the daemon's environment
+-- decides, in POSIX precedence. Every candidate is probed against the actual
+-- locale directory, so an unknown tag falls through instead of blanking the
+-- property titles.
+local function locale_tags(ctx, dir)
+    if _tag_cache then return _tag_cache end
+
+    local candidates = {}
+    local function add(tag)
+        if tag and tag ~= "" then table.insert(candidates, tag) end
     end
+
+    local configured = ctx.config.get("wallpaper_engine_locale")
+    if configured and configured ~= "" then
+        add(string.lower(configured))
+    end
+
+    local env = nil
+    for _, name in ipairs({ "LC_ALL", "LC_MESSAGES", "LANG" }) do
+        local v = ctx.env(name)
+        if v and v ~= "" and v ~= "C" and v ~= "POSIX" then
+            env = v
+            break
+        end
+    end
+    if env then
+        local lang, region = split_posix_locale(env)
+        if lang then
+            if region then
+                add(lang .. "-" .. region)
+                add(LOCALE_ALIASES[lang .. "-" .. region])
+            end
+            add(lang .. "-" .. lang)
+            add(LOCALE_ALIASES[lang])
+        end
+    end
+
+    local tag = nil
+    for _, candidate in ipairs(candidates) do
+        if ctx.fs.exists(dir .. "ui_" .. candidate .. ".json") then
+            tag = candidate
+            break
+        end
+    end
+
+    _tag_cache = { tag = tag, fallback = FALLBACK_TAG }
+    return _tag_cache
+end
+
+local function read_locale_file(ctx, path)
+    if not ctx.fs.exists(path) then return nil end
     local content = ctx.fs.read(path)
-    if not content then
-        _locale_cache[library_root] = false
-        return nil
-    end
+    if not content then return nil end
     local parsed = ctx.json.parse(content)
-    if type(parsed) ~= "table" then
-        _locale_cache[library_root] = false
-        return nil
-    end
-    _locale_cache[library_root] = parsed
+    if type(parsed) ~= "table" then return nil end
     return parsed
+end
+
+-- Returns the translated table and the English one. Wallpaper Engine's
+-- translated files trail en-us by a few dozen keys; without the English
+-- table behind them those properties would show their raw locale key.
+local function load_locale(ctx, library_root)
+    if library_root == nil or library_root == "" then return nil, nil end
+    local cached = _locale_cache[library_root]
+    if cached ~= nil then
+        if cached == false then return nil, nil end
+        return cached.localized, cached.fallback
+    end
+
+    local dir = library_root .. LOCALE_DIR
+    local tags = locale_tags(ctx, dir)
+    local fallback = read_locale_file(ctx, dir .. "ui_" .. tags.fallback .. ".json")
+    local localized = nil
+    if tags.tag and tags.tag ~= tags.fallback then
+        localized = read_locale_file(ctx, dir .. "ui_" .. tags.tag .. ".json")
+    end
+
+    if not localized and not fallback then
+        _locale_cache[library_root] = false
+        return nil, nil
+    end
+    _locale_cache[library_root] = { localized = localized, fallback = fallback }
+    return localized, fallback
 end
 
 local PROPERTY_KEY_MAP = {
@@ -111,11 +200,14 @@ function M.properties(entry, ctx)
     if not props then return nil end
     map_property_keys(props)
 
-    local locale = load_locale(ctx, entry.library_root)
-    if locale then
+    local locale, locale_fallback = load_locale(ctx, entry.library_root)
+    if locale or locale_fallback then
         for _, v in pairs(props) do
             if type(v) == "table" and type(v.text) == "string" then
-                local mapped = locale[v.text]
+                local mapped = locale and locale[v.text] or nil
+                if type(mapped) ~= "string" or mapped == "" then
+                    mapped = locale_fallback and locale_fallback[v.text] or nil
+                end
                 if type(mapped) == "string" and mapped ~= "" then
                     v.text = mapped
                 end


### PR DESCRIPTION
Wallpaper property titles are not free text. `project.json` stores locale keys
(`ui_browse_properties_scheme_color`), and Wallpaper Engine resolves them against
the tables in `steamapps/common/wallpaper_engine/locale`. The plugin read
`ui_en-us.json` and nothing else, so a non-English user got English property
names inside an otherwise translated UI — even though Steam had already
downloaded the other tables into the same directory (36 `ui_*.json` on my
install, `ui_ru-ru.json` among them with 3298 keys).

The table is now picked from `$LC_ALL` / `$LC_MESSAGES` / `$LANG`. Wallpaper
Engine names those files after its own language list rather than after the POSIX
locale, so the tag is tried as `<lang>-<region>`, then `<lang>-<lang>`, then
through a short alias table for the ones neither shape reaches (`zh_CN` →
`zh-chs`, `ja` → `ja-jp`, ...). Every candidate is probed against the directory
before it is used, so an unfamiliar locale falls through instead of emptying the
titles. `wallpaper_engine_locale` overrides the lot when the daemon's
environment carries no locale at all.

`ui_en-us.json` stays loaded behind the chosen table: the translated files trail
en-us by a few dozen keys, and without English behind them those properties
would start showing their raw locale key instead of the name they show today.

Checked against a running 0.3.5 daemon under `LANG=ru_RU.UTF-8`, not only in
tests: `WallpaperGet` on a subscribed video wallpaper returned `Scheme color`
before the change and `Цветовая схема` after it, with the plugin loaded from the
daemon's own plugin directory.

The contract test covers the three outcomes — translated key, key present only
in en-us, key in neither. Tag selection was also run against a real Wallpaper
Engine locale directory for ru, de, zh_CN, zh_TW, pt_BR, ja, cs, uk, en, nb,
bare `ru`, `C` and an unknown locale: 13/13, with the title read back in each
language. Details in a comment below.

This covers one piece of waywallen/waywallen#210 — property titles only; other
plugin-supplied UI strings still have no route to translation.
