### PR TITLE
scene: dispatch timeline animation events to layer scripts

### DIFF
--- a/src/Scene/Pkg/Parse/Scene/SceneAnimationBinding.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneAnimationBinding.cpp
@@ -43,16 +43,34 @@ Vec<SceneAnimationKey> ToSceneAnimationAxis(const std::vector<owe::wpscene::Anim
     return result;
 }
 
+Vec<SceneAnimationEvent>
+ToSceneAnimationEvents(const std::vector<owe::wpscene::AnimEvent>& events) {
+    Vec<SceneAnimationEvent> result;
+    result.reserve(usize(events.size()));
+    for (const auto& event : events)
+        result.push(SceneAnimationEvent {
+            .frame = event.frame,
+            .name  = String::make(rstd::cppstd::as_str(event.name).unwrap()),
+        });
+    sort_unstable_by(result.as_mut_slice().as_mut_ref(),
+                     [](const SceneAnimationEvent& left, const SceneAnimationEvent& right) {
+                         return left.frame < right.frame;
+                     });
+    return result;
+}
+
 SceneAnimationCurve BuildSceneAnimationCurve(const owe::wpscene::AnimCurve& curve) {
     return SceneAnimationCurve {
-        .c0       = ToSceneAnimationAxis(curve.c0),
-        .c1       = ToSceneAnimationAxis(curve.c1),
-        .c2       = ToSceneAnimationAxis(curve.c2),
-        .fps      = curve.options.fps,
-        .length   = curve.options.length,
-        .mode     = String::make(rstd::cppstd::as_str(curve.options.mode).unwrap()),
-        .wraploop = curve.options.wraploop,
-        .relative = curve.relative,
+        .c0          = ToSceneAnimationAxis(curve.c0),
+        .c1          = ToSceneAnimationAxis(curve.c1),
+        .c2          = ToSceneAnimationAxis(curve.c2),
+        .events      = ToSceneAnimationEvents(curve.options.events),
+        .fps         = curve.options.fps,
+        .length      = curve.options.length,
+        .mode        = String::make(rstd::cppstd::as_str(curve.options.mode).unwrap()),
+        .wraploop    = curve.options.wraploop,
+        .relative    = curve.relative,
+        .startpaused = curve.options.startpaused,
     };
 }
 

--- a/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
+++ b/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
@@ -273,6 +273,10 @@ auto ExpandSceneObjects(ref<wpscene::SceneDocument>, mut_ref<fs::VFS>, Option<re
 
 void AssignNodeFieldAnimations(SceneNode&, const wpscene::FieldBindings&);
 auto ToSceneAnimationCurve(const wpscene::AnimCurve&) -> SceneAnimationCurve;
+// Feed a field script the markers of every animation that drives its field,
+// either directly or as one of the animation's children.
+void WireAnimationEventSources(script::JsRuntime&, script::FieldScript&,
+                               const wpscene::FieldBindings&, std::string_view);
 void AssignAnimationCurve(SceneAnimationCurve&, const wpscene::FieldBindings&, ref<str>);
 void LoadRootCameraPaths(SceneParseContext&, const wpscene::SceneMetadata&);
 

--- a/src/Scene/Pkg/Parse/Scene/SceneScriptBinding.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneScriptBinding.cpp
@@ -370,6 +370,21 @@ Json ScriptInitialValueForField(std::string_view field, const Json& value) {
 namespace owe
 {
 
+// Markers live on the animation, the callback lives on the script, and the
+// two are joined by the field name they hang off. One timeline can also
+// drive sibling fields (`options.children`) — those scripts hear it too.
+void WireAnimationEventSources(script::JsRuntime& runtime, script::FieldScript& script,
+                               const wpscene::FieldBindings& fb, std::string_view field) {
+    for (const auto& [animated_field, curve] : fb.animations) {
+        if (curve.options.events.empty()) continue;
+        bool drives_field = animated_field == field;
+        for (const auto& child : curve.options.children) {
+            if (child == field) drives_field = true;
+        }
+        if (drives_field) runtime.AddAnimationEventSource(script, ToSceneAnimationCurve(curve));
+    }
+}
+
 void WireFieldScripts(SceneParseContext& context, const Arc<SceneNode>& node_sp,
                       const wpscene::FieldBindings&                   fb,
                       std::function<void(const script::ScriptValue&)> origin_apply,
@@ -419,6 +434,7 @@ void WireFieldScripts(SceneParseContext& context, const Arc<SceneNode>& node_sp,
         auto        initial_value = ScriptInitialValueForField(field, sb.initial_value);
         auto*       fs = rt.MakeFieldScript(sb.source, sha, kind, props, initial_value, node);
         if (! fs) continue;
+        WireAnimationEventSources(rt, *fs, fb, field);
         SetScriptInitializationOrder(context, *fs, node);
         TrackRegisteredAssets(context, fs);
         if (! has_actuator) continue;

--- a/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
@@ -1107,6 +1107,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
                                                        sb.initial_value,
                                                        layer_node.as_ptr());
         if (fs) {
+            WireAnimationEventSources(ss.runtime(), *fs, obj.field_bindings, "text");
             SetScriptInitializationOrder(context, *fs, layer_node.as_ptr());
             TrackRegisteredAssets(context, fs);
             ss.AddActuator({

--- a/src/Scene/Pkg/SceneObj/FieldBinding.cpp
+++ b/src/Scene/Pkg/SceneObj/FieldBinding.cpp
@@ -41,6 +41,13 @@ bool ParseAnimAxis(const owe::Json& json, std::vector<AnimKeyframe>& out) {
     return true;
 }
 
+bool ParseAnimEvent(const owe::Json& json, AnimEvent& out) {
+    if (! json.is_object()) return false;
+    owe::GetJsonValue(json, "frame", out.frame, false);
+    owe::GetJsonValue(json, "name", out.name, false);
+    return ! out.name.empty();
+}
+
 bool ParseAnimOptions(const owe::Json& json, AnimOptions& out) {
     if (! json.is_object()) return false;
     owe::GetJsonValue(json, "fps", out.fps, false);
@@ -50,9 +57,24 @@ bool ParseAnimOptions(const owe::Json& json, AnimOptions& out) {
     owe::GetJsonValue(json, "startpaused", out.startpaused, false);
     owe::GetJsonValue(json, "wraploop", out.wraploop, false);
     if (auto value = json.get("smoothing"_str); value.is_some()) out.smoothing = (*value)->clone();
-    if (auto value = json.get("children"_str); value.is_some()) out.children = (*value)->clone();
-    if (auto value = json.get("events"_str); value.is_some()) out.events = (*value)->clone();
     if (auto value = json.get("parent"_str); value.is_some()) out.parent = (*value)->clone();
+    if (auto value = json.get("children"_str); value.is_some()) {
+        if (auto array = (*value)->as_array(); array.is_some()) {
+            for (const auto& entry : **array) {
+                std::string key;
+                if (owe::GetJsonValue(entry, "key", key, false) && ! key.empty())
+                    out.children.push_back(std::move(key));
+            }
+        }
+    }
+    if (auto value = json.get("events"_str); value.is_some()) {
+        if (auto array = (*value)->as_array(); array.is_some()) {
+            for (const auto& entry : **array) {
+                AnimEvent event;
+                if (ParseAnimEvent(entry, event)) out.events.push_back(std::move(event));
+            }
+        }
+    }
     return true;
 }
 
@@ -79,9 +101,9 @@ auto AnimCurve::clone() const -> AnimCurve {
     result.options.startpaused = options.startpaused;
     result.options.wraploop    = options.wraploop;
     result.options.smoothing   = options.smoothing.clone();
-    result.options.children    = options.children.clone();
-    result.options.events      = options.events.clone();
     result.options.parent      = options.parent.clone();
+    result.options.children    = options.children;
+    result.options.events      = options.events;
     result.relative            = relative;
     return result;
 }

--- a/src/Scene/Pkg/SceneObj/FieldBinding.cppm
+++ b/src/Scene/Pkg/SceneObj/FieldBinding.cppm
@@ -44,6 +44,15 @@ struct AnimKeyframe {
     AnimKeyframeTangent back;
 };
 
+// One timeline marker. The editor drops these on an animation and the
+// wallpaper reacts to them from the layer's `animationEvent(event, value)`
+// export — that is the only way a scene script learns where a timeline
+// currently is.
+struct AnimEvent {
+    i32         frame { 0 };
+    std::string name;
+};
+
 struct AnimOptions {
     float       fps { 30.0f };
     i32         length { 0 };
@@ -54,9 +63,11 @@ struct AnimOptions {
     // `smoothing` may be null/int/float in the corpus; kept as raw json
     // until a renderer consumer needs it.
     owe::Json smoothing;
-    owe::Json children; // array of nested anim refs
-    owe::Json events;   // array of marker objects
-    owe::Json parent;   // object describing parent anim
+    owe::Json parent; // object describing parent anim
+    // Sibling fields driven by the same timeline (`[{"key": "origin"}]`).
+    // Their scripts see this animation's markers too.
+    std::vector<std::string> children;
+    std::vector<AnimEvent>   events;
 };
 
 struct AnimCurve : rstd::DefaultInClass<AnimCurve, rstd::clone::Clone> {
@@ -73,6 +84,7 @@ struct AnimCurve : rstd::DefaultInClass<AnimCurve, rstd::clone::Clone> {
 bool ParseAnimKeyframeTangent(const owe::Json&, AnimKeyframeTangent&);
 bool ParseAnimKeyframe(const owe::Json&, AnimKeyframe&);
 bool ParseAnimAxis(const owe::Json&, std::vector<AnimKeyframe>&);
+bool ParseAnimEvent(const owe::Json&, AnimEvent&);
 bool ParseAnimOptions(const owe::Json&, AnimOptions&);
 bool ParseAnimCurve(const owe::Json&, AnimCurve&);
 

--- a/src/Scene/Scene/Scene.cpp
+++ b/src/Scene/Scene/Scene.cpp
@@ -169,16 +169,27 @@ struct AnimationFrame {
     bool  wraps { false };
 };
 
-AnimationFrame animation_frame(const SceneAnimationCurve& curve, double runtime) {
-    float fps         = curve.fps > 0.0f ? curve.fps : 30.0f;
-    float frame       = static_cast<float>(runtime) * fps;
-    i32   end         = curve.length;
-    auto  absorb_last = [&end](slice<SceneAnimationKey> keys) {
+// Last frame of the timeline: the authored length, stretched to cover a
+// keyframe that sits past it.
+i32 curve_end(const SceneAnimationCurve& curve) {
+    i32  end         = curve.length;
+    auto absorb_last = [&end](slice<SceneAnimationKey> keys) {
         if (! keys.is_empty()) end = std::max(end, keys[keys.len() - usize(1)].frame);
     };
     absorb_last(curve.c0.as_slice());
     absorb_last(curve.c1.as_slice());
     absorb_last(curve.c2.as_slice());
+    return end;
+}
+
+bool curve_loops(const SceneAnimationCurve& curve) {
+    return curve.wraploop || curve.mode == "loop"_str || curve.mode == "repeat"_str;
+}
+
+AnimationFrame animation_frame(const SceneAnimationCurve& curve, double runtime) {
+    float fps   = curve.fps > 0.0f ? curve.fps : 30.0f;
+    float frame = static_cast<float>(runtime) * fps;
+    i32   end   = curve_end(curve);
     if (end <= i32()) return { .current = frame, .end = end };
 
     const float ef = rstd::as_cast<float>(end);
@@ -189,8 +200,7 @@ AnimationFrame animation_frame(const SceneAnimationCurve& curve, double runtime)
         return { .current = m <= ef ? m : (period - m), .end = end };
     }
 
-    bool loop = curve.wraploop || curve.mode == "loop"_str || curve.mode == "repeat"_str;
-    if (loop) {
+    if (curve_loops(curve)) {
         frame = std::fmod(frame, ef);
         if (frame < 0.0f) frame += ef;
         return { .current = frame, .end = end, .wraps = curve.wraploop };
@@ -964,6 +974,88 @@ Eigen::Vector3f SceneAnimationCurve::EvaluateVec3(const Eigen::Vector3f& base,
         value.z() =
             relative ? base.z() + eval_axis(c2.as_slice(), frame) : eval_axis(c2.as_slice(), frame);
     return value;
+}
+
+SceneAnimationEventCursor::SceneAnimationEventCursor(const SceneAnimationCurve& curve) {
+    if (curve.events.is_empty() || curve.startpaused) return;
+    m_fps    = curve.fps > 0.0f ? curve.fps : 30.0f;
+    m_end    = rstd::as_cast<float>(curve_end(curve));
+    m_loop   = curve_loops(curve);
+    m_mirror = curve.mode == "mirror"_str;
+    if (m_end <= 0.0f) {
+        m_loop   = false;
+        m_mirror = false;
+    }
+    for (usize index {}; index < curve.events.len(); ++index) {
+        const auto& event = curve.events[index];
+        if (m_end > 0.0f && rstd::as_cast<float>(event.frame) > m_end) continue;
+        m_events.push(SceneAnimationEvent { .frame = std::max(event.frame, i32()),
+                                            .name  = event.name.clone() });
+    }
+}
+
+namespace
+{
+// First time at or after `after` at which a playhead of the given period
+// reaches `at`. `None` when it never does again.
+Option<double> next_pass(double at, double after, double period) {
+    if (period <= 0.0) return at > after ? Some(at) : None();
+    double turns = std::floor((after - at) / period) + 1.0;
+    if (turns < 0.0) turns = 0.0;
+    double pass = at + turns * period;
+    while (pass <= after) pass += period;
+    return Some(pass);
+}
+} // namespace
+
+void SceneAnimationEventCursor::Advance(double runtime, Vec<ref<str>>& out) {
+    if (m_events.is_empty()) return;
+    const double now = runtime * static_cast<double>(m_fps);
+    if (! m_primed) {
+        // Start half a frame short of zero so markers sitting on frame 0
+        // fire on the first tick instead of being skipped.
+        m_previous = -0.5;
+        m_primed   = true;
+    }
+    // A restarted scene rewinds the clock; pick the playhead back up there.
+    if (now < m_previous) m_previous = now - 0.5;
+
+    const double end    = static_cast<double>(m_end);
+    const double period = m_mirror ? 2.0 * end : end;
+
+    struct Pass {
+        double   at { 0.0 };
+        ref<str> name;
+    };
+    Vec<Pass> passed;
+    for (usize index {}; index < m_events.len(); ++index) {
+        const auto&    event = m_events[index];
+        const double   frame = static_cast<double>(event.frame.to_primitive());
+        Option<double> pass  = None();
+        if (! m_loop && ! m_mirror) {
+            pass = next_pass(frame, m_previous, 0.0);
+        } else {
+            pass = next_pass(frame, m_previous, period);
+            if (m_mirror && frame > 0.0 && frame < end) {
+                // The playhead passes an interior marker twice per period:
+                // once going up, once coming back down.
+                auto back = next_pass(period - frame, m_previous, period);
+                if (back.is_some() && (pass.is_none() || *back < *pass)) pass = back;
+            }
+        }
+        if (pass.is_none() || *pass > now) continue;
+        passed.push(Pass { .at = *pass, .name = event.name.as_str() });
+    }
+    m_previous = now;
+    if (passed.is_empty()) return;
+    rstd::slice_::sort_unstable_by(passed.as_mut_slice().as_mut_ref(),
+                                   [](const Pass& left, const Pass& right) {
+                                       return left.at < right.at;
+                                   });
+    for (usize index {}; index < passed.len(); ++index) {
+        ref<str> name = passed[index].name;
+        out.push(rstd::move(name));
+    }
 }
 
 void SceneNode::TickFieldAnimations(double runtime) {

--- a/src/Scene/Scene/Scene.cppm
+++ b/src/Scene/Scene/Scene.cppm
@@ -1213,19 +1213,54 @@ struct SceneAnimationKey {
     float back_y { 0.0f };
 };
 
+// A marker on the curve's timeline. Playback crossing `frame` is what a
+// wallpaper's `animationEvent(event, value)` export reacts to.
+struct SceneAnimationEvent {
+    i32    frame {};
+    String name;
+};
+
 struct SceneAnimationCurve {
-    Vec<SceneAnimationKey> c0;
-    Vec<SceneAnimationKey> c1;
-    Vec<SceneAnimationKey> c2;
-    float                  fps { 30.0f };
-    i32                    length {};
-    String                 mode;
-    bool                   wraploop { false };
-    bool                   relative { false };
+    Vec<SceneAnimationKey>   c0;
+    Vec<SceneAnimationKey>   c1;
+    Vec<SceneAnimationKey>   c2;
+    Vec<SceneAnimationEvent> events;
+    float                    fps { 30.0f };
+    i32                      length {};
+    String                   mode;
+    bool                     wraploop { false };
+    bool                     relative { false };
+    bool                     startpaused { false };
 
     bool            Empty() const;
     float           EvaluateScalar(float base, double runtime) const;
     Eigen::Vector3f EvaluateVec3(const Eigen::Vector3f& base, double runtime) const;
+};
+
+// Playhead that reports which of a curve's markers were passed since the
+// previous tick. It runs on the same frame clock the curve is evaluated
+// on, so a marker fires on the frame the curve actually reaches it —
+// including once per pass under `loop`, and once per direction under
+// `mirror`. Markers of a `startpaused` timeline stay silent: nothing
+// advances that playhead until named playback control exists.
+class SceneAnimationEventCursor {
+public:
+    explicit SceneAnimationEventCursor(const SceneAnimationCurve& curve);
+
+    bool Empty() const { return m_events.is_empty(); }
+
+    // Move the playhead to `runtime` and append every marker passed on the
+    // way, in the order they were passed.
+    void Advance(double runtime, Vec<ref<str>>& out);
+
+private:
+    Vec<SceneAnimationEvent> m_events;
+    float                    m_fps { 30.0f };
+    float                    m_end { 0.0f };
+    bool                     m_loop { false };
+    bool                     m_mirror { false };
+    bool                     m_primed { false };
+    double                   m_previous { 0.0 };
 };
 
 struct SceneCameraLookAtKey {

--- a/src/Scene/Script/Script.cpp
+++ b/src/Scene/Script/Script.cpp
@@ -539,6 +539,7 @@ struct FieldScript::Impl {
     JSValue          module_ns { JS_UNDEFINED };
     JSValue          init_fn { JS_UNDEFINED };
     JSValue          update_fn { JS_UNDEFINED };
+    JSValue          animation_event_fn { JS_UNDEFINED };
     bool             update_takes_arg { false };
     bool             init_done { false };
     std::uint64_t    initialization_order { 0 };
@@ -555,7 +556,9 @@ struct FieldScript::Impl {
     JSValue         wrapped_layer { JS_UNDEFINED };
     // Per-script cursor-inside-bbox state used to edge-detect
     // cursorEnter / cursorLeave between frames.
-    bool                                                          cursor_inside { false };
+    bool cursor_inside { false };
+    // Timelines whose markers this script's `animationEvent` reacts to.
+    std::vector<owe::SceneAnimationEventCursor>                   animation_cursors;
     std::unordered_map<std::string, std::vector<owe::SceneNode*>> asset_clone_queues;
     std::unordered_map<owe::SceneNode*, std::string>              clone_asset_keys;
     Vec<String>                                                   registered_assets;
@@ -1023,6 +1026,16 @@ JSValue MakeCursorEvent(JSContext* ctx, const CursorWorld& c, int button) {
     }
     JS_DefinePropertyValueStr(ctx, ev, "worldPosition", wp, JS_PROP_C_W_E);
     JS_DefinePropertyValueStr(ctx, ev, "button", JS_NewInt32(ctx, button), JS_PROP_C_W_E);
+    return ev;
+}
+
+// Build the event object passed to `animationEvent`. Scripts branch on
+// event.name, which is the marker's name as authored on the timeline.
+JSValue MakeAnimationEvent(JSContext* ctx, ref<str> name) {
+    JSValue ev   = JS_NewObject(ctx);
+    auto    text = rstd::cppstd::to_string(name);
+    JS_DefinePropertyValueStr(
+        ctx, ev, "name", JS_NewStringLen(ctx, text.data(), text.size()), JS_PROP_C_W_E);
     return ev;
 }
 
@@ -3180,6 +3193,7 @@ JsRuntime::~JsRuntime() {
     for (auto& fs : m_impl->scripts) {
         if (fs && fs->m_impl) {
             JS_FreeValue(m_impl->ctx, fs->m_impl->update_fn);
+            JS_FreeValue(m_impl->ctx, fs->m_impl->animation_event_fn);
             JS_FreeValue(m_impl->ctx, fs->m_impl->init_fn);
             JS_FreeValue(m_impl->ctx, fs->m_impl->module_ns);
             JS_FreeValue(m_impl->ctx, fs->m_impl->current_value);
@@ -3339,6 +3353,15 @@ void JsRuntime::SetInitializationOrder(FieldScript& script, std::uint64_t order)
     script.m_impl->initialization_order = order;
 }
 
+void JsRuntime::AddAnimationEventSource(FieldScript&                    script,
+                                        const owe::SceneAnimationCurve& curve) {
+    if (! m_impl || ! script.m_impl || script.m_impl->rt != m_impl.get()) return;
+    if (JS_IsUndefined(script.m_impl->animation_event_fn)) return;
+    owe::SceneAnimationEventCursor cursor(curve);
+    if (cursor.Empty()) return;
+    script.m_impl->animation_cursors.push_back(rstd::move(cursor));
+}
+
 void JsRuntime::RegisterInitialLayerConfig(owe::SceneNode* node, Json config) {
     if (! m_impl || node == nullptr) return;
     (void)m_impl->host.initial_layer_configs.insert(node, rstd::move(config));
@@ -3420,6 +3443,46 @@ void JsRuntime::TickAll() {
         }
     }
     if (! JS_IsUndefined(ev_shared)) JS_FreeValue(ctx, ev_shared);
+
+    // Timeline marker dispatch. Each bound curve advances on the clock the
+    // renderer evaluates it on; the markers it passed since the previous
+    // tick fire `animationEvent(event, value)`. Runs before update() so
+    // update sees the state the callbacks wrote this frame.
+    Vec<ref<str>> passed_markers;
+    for (auto& fs : m_impl->scripts) {
+        auto* I = fs->m_impl.get();
+        if (! I->alive || I->animation_cursors.empty()) continue;
+        passed_markers.clear();
+        for (auto& cursor : I->animation_cursors)
+            cursor.Advance(m_impl->host.inputs.runtime, passed_markers);
+        if (passed_markers.is_empty()) continue;
+        BindThisLayer(
+            ctx, JS_IsUndefined(I->wrapped_layer) ? m_impl->host.default_layer : I->wrapped_layer);
+        m_impl->host.active_field_script = fs.get();
+        for (usize index {}; index < passed_markers.len(); ++index) {
+            JSValue args[2] = { MakeAnimationEvent(ctx, passed_markers[index]),
+                                JS_DupValue(ctx, I->current_value) };
+            JSValue ret     = JS_Call(ctx, I->animation_event_fn, JS_UNDEFINED, 2, args);
+            JS_FreeValue(ctx, args[0]);
+            JS_FreeValue(ctx, args[1]);
+            if (JS_IsException(ret)) {
+                m_impl->LogError(ctx, I->sha, "animationEvent threw");
+                JS_FreeValue(ctx, ret);
+                continue;
+            }
+            // The callback may hand back a replacement property value, the
+            // same way update() does; keep it for the update() that follows.
+            auto value = CoerceReturn(ctx, ret, I->kind);
+            if (! std::holds_alternative<std::monostate>(value)) {
+                JSValue next_value = ScriptValueToJs(ctx, value);
+                JS_FreeValue(ctx, I->current_value);
+                I->current_value = next_value;
+                I->last_value    = std::move(value);
+            }
+            JS_FreeValue(ctx, ret);
+        }
+    }
+    m_impl->host.active_field_script = nullptr;
 
     for (auto& fs : m_impl->scripts) {
         auto* I = fs->m_impl.get();
@@ -3696,6 +3759,14 @@ FieldScript* JsRuntime::MakeFieldScript(std::string_view source, std::string_vie
     } else {
         JS_FreeValue(ctx, update_fn);
         I->update_fn = JS_UNDEFINED;
+    }
+    // Cache `animationEvent` the same way; timeline markers dispatch into it.
+    JSValue animation_event_fn = JS_GetPropertyStr(ctx, ns, "animationEvent");
+    if (JS_IsFunction(ctx, animation_event_fn)) {
+        I->animation_event_fn = animation_event_fn;
+    } else {
+        JS_FreeValue(ctx, animation_event_fn);
+        I->animation_event_fn = JS_UNDEFINED;
     }
     // Reuse the coerced initial value as the seed for (value)-form
     // updates so the first frame's `update(value)` sees a Vec3, not a

--- a/src/Scene/Script/Script.cppm
+++ b/src/Scene/Script/Script.cppm
@@ -188,6 +188,13 @@ public:
     void SetBoneResolvers(BoneIndexResolver     index_resolver,
                           BoneTransformResolver transform_resolver);
 
+    // Attach a timeline whose markers dispatch this script's
+    // `animationEvent(event, value)` export. A script can be fed by more
+    // than one: its own field's animation, plus any animation that lists
+    // the field among its children. Ignored when the script has no
+    // `animationEvent` export or the curve carries no markers.
+    void AddAnimationEventSource(FieldScript& script, const owe::SceneAnimationCurve& curve);
+
     // Drive every alive FieldScript once. Invokes their cached `update`
     // export and stores the coerced return into FieldScript::last_value().
     // Exceptions are caught and logged once per script_sha.


### PR DESCRIPTION
Wallpaper Engine timelines can carry named markers, and a layer script reacts to them through its `animationEvent(event, value)` export. OWE parses those markers into `AnimOptions::events` and then nobody reads that field: `BuildSceneAnimationCurve` doesn't carry them into the runtime curve, and the script runtime only knows `init`, `update` and `applyUserProperties`. So the export never runs and every wallpaper built around it stands still.

The markers now become a typed list on `SceneAnimationCurve`, and each bound script gets a small playhead that reports the markers a curve passed since the previous tick — once per pass under `loop`, once per direction under `mirror`. Dispatch runs before `update()` of the same frame, the way the cursor callbacks already do, and a value returned from the callback seeds the following `update(value)` exactly like update's own return.

A `startpaused` timeline stays silent: nothing can start it while `getAnimation("x").play()` is a stub, and firing its markers at scene start would be plain wrong. An animation that lists sibling fields in `options.children` hands its markers to their scripts too — that grouping is how the editor writes it.

Star Fox (3425253832) is the wallpaper I checked this on. It hangs the whole dialogue on one looping 450-frame timer, so without markers the ships just fly in silence. With the change the speaker portrait, name, line and voice switch every 15 seconds and the barrel rolls and boosts run again. Marker times measured in SceneViewer land on the authored frames within one tick: talkend 50, endbarrel 120, endboost 230, static 405, talk 420, time 450, then the same again every 450 frames.

Markers are rare but load-bearing. Of the 8 scene wallpapers I have installed only Star Fox carries any; I ran all 8 before and after, and nothing but Star Fox changed.
