### PR TITLE
scene: honour scripts bound to an effect's visibility

### DIFF
--- a/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
@@ -666,7 +666,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
         const bool passthrough_can_composite_final =
             isPassthrough || ! parse_geometry.requires_source_draw;
         for (const auto& wpeffobj : wpimgobj.effects) {
-            if (! wpeffobj.visible && wpeffobj.visible_user.empty()) {
+            if (! wpeffobj.visible && ! wpeffobj.visible_can_change()) {
                 continue;
             }
             std::shared_ptr<SceneImageEffect> imgEffect = std::make_shared<SceneImageEffect>();
@@ -677,6 +677,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 imgEffect->visible_user_binding =
                     ToSceneUserVisibilityBinding(wpeffobj.visible_user);
             }
+            WireImageEffectVisibilityScript(context, spImgNode.as_ptr(), wpeffobj, effect_id);
 
             const std::string inRT { effect_composite };
 
@@ -1166,7 +1167,7 @@ void ParseShapeObj(SceneParseContext& context, wpscene::ShapeObject& shape_obj) 
     const wpscene::ImageEffect* first_effect { nullptr };
     const wpscene::ImageEffect* last_effect { nullptr };
     for (const auto& effect : shape_obj.effects) {
-        if (! effect.visible && effect.visible_user.empty()) continue;
+        if (! effect.visible && ! effect.visible_can_change()) continue;
         if (first_effect == nullptr) first_effect = &effect;
         last_effect = &effect;
     }

--- a/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
+++ b/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
@@ -213,6 +213,8 @@ auto ScriptValueAsVec3(const script::ScriptValue&, const Eigen::Vector3f&)
 void WireFieldScripts(SceneParseContext&, const Arc<SceneNode>&, const wpscene::FieldBindings&,
                       std::function<void(const script::ScriptValue&)> = {},
                       std::function<void(const script::ScriptValue&)> = {});
+void WireImageEffectVisibilityScript(SceneParseContext&, SceneNode*, const wpscene::ImageEffect&,
+                                     SceneEffectId);
 void WireCameraShakeScripts(SceneParseContext&, const wpscene::FieldBindings&);
 void WireCameraFieldScripts(SceneParseContext&, const Arc<SceneNode>&, const Arc<SceneCamera>&,
                             const Arc<SceneCameraPath>&, const wpscene::FieldBindings&,

--- a/src/Scene/Pkg/Parse/Scene/SceneMaterialBuilder.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneMaterialBuilder.cpp
@@ -74,7 +74,7 @@ ShaderValueMap NeutralColorUniforms(ShaderValueMap values) {
 i32 CountVisibleImageEffects(std::span<const wpscene::ImageEffect> effects) {
     i32 count {};
     for (const auto& effect : effects) {
-        if (effect.visible || ! effect.visible_user.empty()) count += i32(1);
+        if (effect.visible || effect.visible_can_change()) count += i32(1);
     }
     return count;
 }

--- a/src/Scene/Pkg/Parse/Scene/SceneScriptBinding.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneScriptBinding.cpp
@@ -437,6 +437,33 @@ void WireFieldScripts(SceneParseContext& context, const Arc<SceneNode>& node_sp,
     }
 }
 
+// An effect's `visible` can be driven by a script, the same way a layer's
+// can. The effect is already registered with the scene, so the actuator
+// only has to flip its runtime visibility; the render graph rebuild is
+// handled by Scene::SetImageEffectRuntimeVisible.
+void WireImageEffectVisibilityScript(SceneParseContext& context, SceneNode* node,
+                                     const wpscene::ImageEffect& effect, SceneEffectId effect_id) {
+    const auto* sb = effect.visible_script();
+    if (sb == nullptr || ! effect_id.Valid()) return;
+
+    auto&       ss  = EnsureScriptScene(context);
+    auto&       rt  = ss.runtime();
+    std::string sha = utils::genSha1(std::span<const char>(sb->source));
+    auto*       fs  = rt.MakeFieldScript(
+        sb->source, sha, script::FieldKind::Bool, sb->properties, sb->initial_value, node);
+    if (! fs) return;
+    SetScriptInitializationOrder(context, *fs, node);
+    TrackRegisteredAssets(context, fs);
+
+    auto* scene = context.scene.get();
+    ss.AddActuator({ fs, [scene, effect_id](const script::ScriptValue& value) {
+                        auto flag = ScriptValueAsFloat(value);
+                        if (! flag) return;
+                        (void)scene->SetImageEffectRuntimeVisible({ .id = effect_id },
+                                                                  *flag >= 0.5f);
+                    } });
+}
+
 void WireCameraShakeScripts(SceneParseContext& context, const wpscene::FieldBindings& fb) {
     if (fb.scripts.empty()) return;
 

--- a/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
@@ -207,7 +207,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
                               has_text_user || context.scene_layer_text_writes;
     bool has_text_effect    = false;
     for (const auto& effect : obj.effects) {
-        if (effect.visible || ! effect.visible_user.empty()) {
+        if (effect.visible || effect.visible_can_change()) {
             has_text_effect = true;
             break;
         }
@@ -693,7 +693,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
             layer->SetFinalMaterialState(final_state);
 
             for (const auto& wpeffobj : obj.effects) {
-                if (! wpeffobj.visible && wpeffobj.visible_user.empty()) continue;
+                if (! wpeffobj.visible && ! wpeffobj.visible_can_change()) continue;
 
                 auto effect             = std::make_shared<SceneImageEffect>();
                 effect->name            = wpeffobj.name;
@@ -703,6 +703,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
                     effect->visible_user_binding =
                         ToSceneUserVisibilityBinding(wpeffobj.visible_user);
                 }
+                WireImageEffectVisibilityScript(context, layer_node.as_ptr(), wpeffobj, effect_id);
 
                 const std::string   inRT { composite };
                 EffectRenderTargets render_targets;

--- a/src/Scene/Pkg/SceneObj/ImageObject.cpp
+++ b/src/Scene/Pkg/SceneObj/ImageObject.cpp
@@ -148,6 +148,7 @@ bool ImageEffect::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion v) 
     owe::GetJsonValue(json, "file", filePath);
     ReadVisibleProperty(json, visible, visible_user);
     visible_user_key = visible_user.name;
+    AbsorbAllFieldBindings(json, field_bindings);
     owe::GetJsonValue(json, "name", name, false);
     owe::GetJsonValue(json, "username", username, false);
     owe::GetJsonValue(json, "id", id, false);

--- a/src/Scene/Pkg/SceneObj/ImageObject.cppm
+++ b/src/Scene/Pkg/SceneObj/ImageObject.cppm
@@ -71,6 +71,20 @@ public:
     std::vector<MaterialPass>  passes;
     std::vector<EffectCommand> commands;
     std::vector<EffectFbo>     fbos;
+    // `visible` can also be `{"value": false, "script": "..."}`. The script
+    // decides every frame whether the effect draws, so the authored value
+    // says nothing about whether the effect is ever needed.
+    FieldBindings field_bindings;
+
+    // True when something other than the authored value can turn this effect
+    // on later: a user property, or a script bound to `visible`.
+    bool visible_can_change() const {
+        return ! visible_user.empty() || field_bindings.scripts.contains("visible");
+    }
+    const ScriptBinding* visible_script() const {
+        auto it = field_bindings.scripts.find("visible");
+        return it == field_bindings.scripts.end() ? nullptr : &it->second;
+    }
 };
 
 class ImageObject {


### PR DESCRIPTION
Star Fox (workshop 3425253832) hangs the character portraits on the dialogue box layer as effects, and each one carries a script on its `visible` field that turns it on while that character is speaking. The parser reads only the initial value and drops the script, and an effect whose initial value is false is never built at all, so no portrait ever shows up — what you see in the mugshot window is the VHS static layer that sits under them.

An effect now keeps its field bindings, stays in the scene as long as a script or a user property can still switch it on, and takes its runtime visibility from the script through Scene::SetImageEffectRuntimeVisible.

Checked with SceneViewer on CachyOS, RADV on a Radeon 780M, against 3425253832 and 2938612768 plus the six other scene wallpapers I have installed, and nothing else moved. On Star Fox the portraits only come up together with #111, because the dialogue itself is driven by timeline events.
