### PR TITLE
text: wrap text layers at maxwidth

### DIFF
--- a/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
@@ -433,6 +433,9 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
     style.background_brightness = obj.backgroundbrightness;
     style.halign                = obj.horizontalalign.empty() ? obj.alignment : obj.horizontalalign;
     style.padding               = rstd::as_cast<float>(obj.padding);
+    if (obj.limitwidth && obj.maxwidth > 0.0f) style.wrap_width = obj.maxwidth;
+    if (obj.limitrows && obj.maxrows > u32()) style.max_rows = obj.maxrows.to_primitive();
+    style.row_limit_ellipsis = obj.limituseellipsis;
 
     auto align_or_default = [](std::string      value,
                                std::string_view fallback,
@@ -504,8 +507,13 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
     layer_node->SetReflected(obj.reflected);
     layer_node->ID() = obj.id;
 
-    const float                    object_w = obj.size[0] > 0.0f ? obj.size[0] : text_bbox_w;
-    const float                    object_h = obj.size[1] > 0.0f ? obj.size[1] : text_bbox_h;
+    // A layer that limits its width lays its text out inside a maxwidth box.
+    // The authored `size` only measures the text the layer shipped with, which
+    // on a scripted layer is a placeholder ("..." in workshop 3425253832), so
+    // on its own it clips every longer message the script writes.
+    const float limit_w  = style.wrap_width > 0.0f ? style.wrap_width + 2.0f * style.padding : 0.0f;
+    const float object_w = std::max(obj.size[0] > 0.0f ? obj.size[0] : text_bbox_w, limit_w);
+    const float object_h = obj.size[1] > 0.0f ? obj.size[1] : text_bbox_h;
     const text::TextGeometryPolicy geometry_policy {
         .frame_width        = object_w,
         .frame_height       = object_h,

--- a/src/Scene/Text/Text.cpp
+++ b/src/Scene/Text/Text.cpp
@@ -791,7 +791,13 @@ namespace
 struct TextLineRunGI {
     std::vector<const GlyphInfo*> glyphs;
     float                         width { 0.0f };
+    // Glyph index just past the last break opportunity on this line, i.e.
+    // where the word currently being filled starts. 0 means the line holds
+    // one unbroken word.
+    std::size_t word_start { 0 };
 };
+
+bool IsBreakSpace(std::uint32_t cp) noexcept { return cp == ' ' || cp == '\t'; }
 
 bool ContainsSubstring(std::string_view s, std::string_view what) noexcept {
     return s.find(what) != std::string::npos;
@@ -941,7 +947,11 @@ void TextLayouter::SetText(std::string_view utf8) {
     im.current_text = std::move(next_text);
     auto codepoints = DecodeUtf8(im.current_text);
 
-    // Split into lines and look up pre-rasterised glyph metrics.
+    // Split into lines and look up pre-rasterised glyph metrics. A layer with
+    // `limitwidth` also wraps on word boundaries once a line would grow past
+    // `maxwidth`; a word that does not fit on a line of its own is broken
+    // where it runs out of room.
+    const float                wrap = im.style.wrap_width;
     std::vector<TextLineRunGI> lines;
     lines.emplace_back();
     std::size_t total_glyph_quads = 0;
@@ -961,9 +971,66 @@ void TextLayouter::SetText(std::string_view utf8) {
             }
             continue;
         }
-        lines.back().glyphs.push_back(gi);
-        lines.back().width += gi->advance_x;
+        if (wrap > 0.0f && ! lines.back().glyphs.empty() &&
+            lines.back().width + gi->advance_x > wrap) {
+            if (IsBreakSpace(cp)) {
+                // The break falls on the space itself; drop it rather than
+                // carry it to the head of the next line.
+                lines.emplace_back();
+                continue;
+            }
+            auto&             line  = lines.back();
+            const std::size_t start = line.word_start;
+            if (start > 0 && start < line.glyphs.size()) {
+                TextLineRunGI next;
+                next.glyphs.assign(line.glyphs.begin() + static_cast<std::ptrdiff_t>(start),
+                                   line.glyphs.end());
+                for (const auto* moved : next.glyphs) next.width += moved->advance_x;
+                line.glyphs.resize(start);
+                line.width -= next.width;
+                // The space that ended the word stays behind; it is invisible
+                // but would still count towards the finished line's width.
+                while (! line.glyphs.empty() && line.glyphs.back()->pixel_w == 0 &&
+                       line.glyphs.back()->pixel_h == 0) {
+                    line.width -= line.glyphs.back()->advance_x;
+                    line.glyphs.pop_back();
+                }
+                line.word_start = 0;
+                lines.push_back(std::move(next));
+            } else {
+                lines.emplace_back();
+            }
+        }
+        auto& line = lines.back();
+        line.glyphs.push_back(gi);
+        line.width += gi->advance_x;
+        if (IsBreakSpace(cp)) line.word_start = line.glyphs.size();
         if (gi->pixel_w != 0 && gi->pixel_h != 0) ++total_glyph_quads;
+    }
+
+    // `maxrows` drops whatever did not fit; `limituseellipsis` marks the cut
+    // by replacing the tail of the last kept row with an ellipsis.
+    if (im.style.max_rows > 0 && lines.size() > im.style.max_rows) {
+        if (im.style.row_limit_ellipsis) {
+            const auto* dot = im.face->Lookup('.');
+            if (dot != nullptr) {
+                auto& last = lines[im.style.max_rows - 1];
+                while (! last.glyphs.empty() &&
+                       (wrap > 0.0f && last.width + 3.0f * dot->advance_x > wrap)) {
+                    last.width -= last.glyphs.back()->advance_x;
+                    last.glyphs.pop_back();
+                }
+                for (int i = 0; i < 3; ++i) {
+                    last.glyphs.push_back(dot);
+                    last.width += dot->advance_x;
+                }
+            }
+        }
+        lines.resize(im.style.max_rows);
+        total_glyph_quads = 0;
+        for (const auto& line : lines)
+            for (const auto* gi : line.glyphs)
+                if (gi->pixel_w != 0 && gi->pixel_h != 0) ++total_glyph_quads;
     }
 
     bool        has_bg      = im.style.opaquebackground;
@@ -989,6 +1056,10 @@ void TextLayouter::SetText(std::string_view utf8) {
     float text_w = 0.0f;
     for (auto& l : lines)
         if (l.width > text_w) text_w = l.width;
+    // A wrapping layer aligns its lines inside the maxwidth box rather than
+    // against the longest line, so a message shorter than the box still
+    // starts at the left edge of a left-aligned layer.
+    if (wrap > 0.0f) text_w = std::max(text_w, wrap);
     float text_h =
         fm.ascender - fm.descender + static_cast<float>(lines.size() - 1) * fm.line_height;
     im.last_text_w          = text_w;
@@ -1142,7 +1213,10 @@ void TextLayouter::SetText(std::string_view utf8) {
         if (emitted_glyphs >= total_glyph_quads) break;
     }
 
-    if (have_glyph_bounds) {
+    // A wrapping layer keeps its maxwidth box as the source rectangle: the
+    // lines are already placed inside that box, and shrinking the source to
+    // the ink would re-centre them and lose the alignment again.
+    if (have_glyph_bounds && wrap <= 0.0f) {
         im.last_source_w               = std::max(1.0f, glyph_max_x - glyph_min_x);
         im.last_source_h               = std::max(1.0f, glyph_max_y - glyph_min_y);
         im.last_source_center_x        = 0.5f * (glyph_min_x + glyph_max_x);

--- a/src/Scene/Text/Text.cppm
+++ b/src/Scene/Text/Text.cppm
@@ -244,6 +244,13 @@ struct TextLayoutStyle {
 
     std::string halign; // "left" / "right" / contains-substring; default = center
     float       padding { 0.0f };
+
+    // Text-flow limits from the layer (`maxwidth` / `maxrows`, gated by
+    // `limitwidth` / `limitrows`). `wrap_width` is in the same pixel space
+    // as the glyph advances; 0 means no wrapping, 0 rows means no limit.
+    float         wrap_width { 0.0f };
+    std::uint32_t max_rows { 0 };
+    bool          row_limit_ellipsis { false };
 };
 
 struct TextLayoutMetrics {


### PR DESCRIPTION
Star Fox (workshop 3425253832) writes its dialogue into a text layer with limitwidth and maxwidth 376, and the layouter only ever breaks on a newline, so a long message runs off both sides of the box and you get to read the middle of it. The frame is lost as well: the layer's authored size measures the "..." placeholder it ships with, not the box the script writes into, so even a wrapped line would be clipped to the width of three dots.

Lines now break on word boundaries once they would grow past maxwidth, a word too long for a line of its own breaks where it runs out of room, rows past maxrows are dropped, and a wrapping layer lays out inside its maxwidth box instead of the authored size. Held against a Windows capture of the same wallpaper it comes out the same: two lines, same left edge, same box.

Checked with SceneViewer on CachyOS, RADV on a Radeon 780M, against the eight scene wallpapers I have installed. One other layer moves: the media player 2938612768 now wraps its placeholder title onto two lines, which is what its own maxwidth of 781 asks for at that point size. On Star Fox the dialogue only advances together with #111.
