### PR TITLE
scene: fix parallax depth routing

### DIFF
--- a/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
@@ -220,13 +220,10 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
     if (color_blend_uses_layer_material && ! hasEffect) ApplyImageColorBlend(image_wpmat, wpimgobj);
     ApplyUserTextureBindings(context, image_wpmat);
     {
-        svData.propagate_parallax_to_children = ! wpimgobj.disablepropagation;
-        svData.propagated_parallax_depth = { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] };
-        if (! hasEffect) {
-            svData.parallax_depth = { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] };
-            if (puppet.is_some() && has_bones) {
-                MdlParser::AddPuppetShaderInfo(shaderInfo, **puppet);
-            }
+        svData.SetParallaxContract({ wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
+                                   wpimgobj.id);
+        if (! hasEffect && puppet.is_some() && has_bones) {
+            MdlParser::AddPuppetShaderInfo(shaderInfo, **puppet);
         }
 
         baseConstSvs[rstd::cppstd::to_string(G_COLOR4)] = std::array<float, 4> {
@@ -811,7 +808,8 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                     ShaderValue::fromMatrix(Eigen::Matrix4f::Identity());
                 SceneMaterial          material;
                 UniformNodeConfigDraft svData;
-                svData.propagate_parallax_to_children = ! wpimgobj.disablepropagation;
+                svData.SetParallaxContract({ wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
+                                           wpimgobj.id);
                 SceneShaderValueAnimationMap final_quad_shader_values;
                 auto effect_result = BuildMaterial(vfs,
                                                    *context.shader_cache,
@@ -831,11 +829,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 LoadConstvalue(material, wpmat, wpEffShaderInfo, &final_quad_shader_values);
                 auto spMesh = std::make_shared<SceneMesh>();
                 {
-                    svData.propagated_parallax_depth = { wpimgobj.parallaxDepth[0],
-                                                         wpimgobj.parallaxDepth[1] };
-                    svData.parallax_depth            = { wpimgobj.parallaxDepth[0],
-                                                         wpimgobj.parallaxDepth[1] };
-                    svData.effect_projection_node    = Some(spImgNode.clone());
+                    svData.effect_projection_node = Some(spImgNode.clone());
                     svData.effect_projection_size = { rstd::as_cast<float>(effect_extent[usize()]),
                                                       rstd::as_cast<float>(
                                                           effect_extent[usize(1)]) };
@@ -986,11 +980,8 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 shader_info.baseConstSvs = NeutralColorUniforms(baseConstSvs);
                 SceneMaterial          material;
                 UniformNodeConfigDraft uniform_config;
-                uniform_config.propagate_parallax_to_children = ! wpimgobj.disablepropagation;
-                uniform_config.propagated_parallax_depth      = { wpimgobj.parallaxDepth[0],
-                                                                  wpimgobj.parallaxDepth[1] };
-                uniform_config.parallax_depth                 = { wpimgobj.parallaxDepth[0],
-                                                                  wpimgobj.parallaxDepth[1] };
+                uniform_config.SetParallaxContract(
+                    { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] }, wpimgobj.id);
                 auto material_result = BuildMaterial(vfs,
                                                      *context.shader_cache,
                                                      context.shader_environment,
@@ -1068,11 +1059,8 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                     wpFinalShaderInfo.baseConstSvs = NeutralColorUniforms(baseConstSvs);
                     SceneMaterial          finalMaterial;
                     UniformNodeConfigDraft finalSvData;
-                    finalSvData.propagate_parallax_to_children = ! wpimgobj.disablepropagation;
-                    finalSvData.propagated_parallax_depth      = { wpimgobj.parallaxDepth[0],
-                                                                   wpimgobj.parallaxDepth[1] };
-                    finalSvData.parallax_depth                 = { wpimgobj.parallaxDepth[0],
-                                                                   wpimgobj.parallaxDepth[1] };
+                    finalSvData.SetParallaxContract(
+                        { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] }, wpimgobj.id);
                     auto final_result = BuildMaterial(vfs,
                                                       *context.shader_cache,
                                                       context.shader_environment,
@@ -1203,21 +1191,23 @@ void ParseShapeObj(SceneParseContext& context, wpscene::ShapeObject& shape_obj) 
     image.visible  = shape_obj.visible;
     image.material = last_effect->materials.back().clone();
     image.material.MergePass(last_effect->passes.back());
-    image.material.blending  = "additive";
-    image.effects            = rstd::move(shape_obj.effects);
-    image.nopadding          = true;
-    image.locktransforms     = shape_obj.locktransforms;
-    image.muteineditor       = shape_obj.muteineditor;
-    image.nointerpolation    = shape_obj.nointerpolation;
-    image.reflected          = shape_obj.reflected;
-    image.castshadow         = shape_obj.castshadow;
-    image.disablepropagation = shape_obj.disablepropagation;
-    image.parent             = shape_obj.parent;
-    image.attachment         = rstd::move(shape_obj.attachment);
-    image.dependencies       = rstd::move(shape_obj.dependencies);
-    image.field_bindings     = rstd::move(shape_obj.field_bindings);
-    image.visible_user       = rstd::move(shape_obj.visible_user);
-    image.visible_user_key   = rstd::move(shape_obj.visible_user_key);
+    image.material.blending     = "additive";
+    image.effects               = rstd::move(shape_obj.effects);
+    image.nopadding             = true;
+    image.locktransforms        = shape_obj.locktransforms;
+    image.muteineditor          = shape_obj.muteineditor;
+    image.nointerpolation       = shape_obj.nointerpolation;
+    image.reflected             = shape_obj.reflected;
+    image.castshadow            = shape_obj.castshadow;
+    image.disablepropagation    = shape_obj.disablepropagation;
+    image.parent                = shape_obj.parent;
+    image.attachment            = rstd::move(shape_obj.attachment);
+    image.dependencies          = rstd::move(shape_obj.dependencies);
+    image.field_bindings        = rstd::move(shape_obj.field_bindings);
+    image.visible_user          = rstd::move(shape_obj.visible_user);
+    image.visible_user_key      = rstd::move(shape_obj.visible_user_key);
+    image.parallaxDepth         = shape_obj.parallaxDepth;
+    image.parallaxDepthAuthored = shape_obj.parallaxDepthAuthored;
     ParseImageObjImpl(context,
                       image,
                       ImageParseGeometry {

--- a/src/Scene/Pkg/Parse/Particle/SceneParticleObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Particle/SceneParticleObjectParser.cpp
@@ -402,9 +402,8 @@ void BuildParticleObjectNode(ParticleObjectParseServices& services,
     UniformNodeConfigDraft svData;
 
     if (! is_child) {
-        svData.parallax_depth = { wppartobj.parallaxDepth[0], wppartobj.parallaxDepth[1] };
-        svData.propagated_parallax_depth = { wppartobj.parallaxDepth[0],
-                                             wppartobj.parallaxDepth[1] };
+        svData.SetParallaxContract({ wppartobj.parallaxDepth[0], wppartobj.parallaxDepth[1] },
+                                   wppartobj.id);
     }
     svData.use_camera_eye_position = particle_obj.flags[wpscene::Particle::FlagEnum::perspective];
     svData.vertices_in_world_space = particle_obj.flags[wpscene::Particle::FlagEnum::wordspace];

--- a/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
+++ b/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
@@ -166,6 +166,8 @@ struct SceneParseContext {
     Vec<i32>                    node_id_order;
     HashMap<i32, std::uint64_t> script_initialization_orders;
     HashMap<i32, Json>          initial_layer_configs;
+    HashSet<i32>                parallax_depth_user_binding_ids;
+    HashSet<i32>                ride_parent_parallax_ids;
 
     i32                             next_synthetic_object_id { -1 };
     Vec<owe::script::FieldScript*>  registered_asset_scripts;
@@ -208,6 +210,7 @@ auto EnsureScriptScene(SceneParseContext&) -> script::ScriptScene&;
 void SetScriptInitializationOrder(SceneParseContext&, script::FieldScript&, const SceneNode*);
 void TrackRegisteredAssets(SceneParseContext&, script::FieldScript*);
 auto ScriptValueAsFloat(const script::ScriptValue&) -> Option<float>;
+auto ScriptValueAsVec2(const script::ScriptValue&) -> Option<array<float, 2>>;
 auto ScriptValueAsVec3(const script::ScriptValue&, const Eigen::Vector3f&)
     -> Option<Eigen::Vector3f>;
 void WireFieldScripts(SceneParseContext&, const Arc<SceneNode>&, const wpscene::FieldBindings&,

--- a/src/Scene/Pkg/Parse/Scene/SceneFinalize.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneFinalize.cpp
@@ -47,13 +47,14 @@ bool RegisterUniformNodeSources(Scene& scene, const Arc<UniformSceneState>& unif
     auto node_id = scene.ResourceIndex().nodeId(*node);
     if (node_id.is_none()) return false;
 
-    auto state = Arc<UniformNodeState>::make(node.clone(), camera_resolver.clone());
-    state->propagated_parallax_depth      = config.propagated_parallax_depth;
-    state->propagate_parallax_to_children = config.propagate_parallax_to_children;
-    state->use_camera_eye_position        = config.use_camera_eye_position;
-    state->eye_position_override          = config.eye_position_override;
-    state->vertices_in_world_space        = config.vertices_in_world_space;
-    state->effect_projection_size         = config.effect_projection_size;
+    auto state            = Arc<UniformNodeState>::make(node.clone(), camera_resolver.clone());
+    state->object_id      = config.object_id;
+    state->parallax_depth = config.parallax_depth;
+    state->ride_parent_parallax    = config.ride_parent_parallax;
+    state->use_camera_eye_position = config.use_camera_eye_position;
+    state->eye_position_override   = config.eye_position_override;
+    state->vertices_in_world_space = config.vertices_in_world_space;
+    state->effect_projection_size  = config.effect_projection_size;
     if (config.effect_projection_node.is_some())
         state->effect_projection_node = Some((*config.effect_projection_node).clone());
     uniform_state->SetNodeState(*node_id, state.clone());
@@ -111,7 +112,8 @@ void FinalizeUniformSources(SceneParseContext& context) {
     auto ortho = scene.Ortho();
     context.uniform_state->SetOrtho(static_cast<float>(ortho[usize()].to_primitive()),
                                     static_cast<float>(ortho[usize(1)].to_primitive()));
-    scene.Runtime().RegisterSystem(UniformRuntimeSystem { context.uniform_state.clone() });
+    scene.Runtime().RegisterSystem(UniformRuntimeSystem { context.uniform_state.clone() },
+                                   SceneRuntimeSchedule::BeforeRender);
 
     auto registrar = dyn<UniformSourceRegistrar>::from_ref(scene);
     auto writer    = dyn<UniformAttachmentWriter>::from_ref(scene);
@@ -181,6 +183,10 @@ void FinalizeUniformSources(SceneParseContext& context) {
     }
 
     for (auto& entry : context.uniform_configs) {
+        if (entry.config.object_id != i32() &&
+            context.ride_parent_parallax_ids.contains(entry.config.object_id)) {
+            entry.config.ride_parent_parallax = true;
+        }
         (void)RegisterUniformNodeSources(
             scene, context.uniform_state, camera_resolver, entry.node, entry.config);
     }
@@ -343,6 +349,7 @@ Box<Scene> FinalizeScene(SceneParseContext& context) {
             const auto& puppet           = **parent_ref->puppet;
             auto        attachment_index = puppet.attachmentIndex(ref.attachment.as_str());
             if (attachment_index.is_some()) {
+                context.ride_parent_parallax_ids.insert(id);
                 auto apply_bind_offset = [&]() {
                     auto anchor = puppet.attachmentBindTransform(*attachment_index);
                     if (anchor.is_none()) return;

--- a/src/Scene/Pkg/Parse/Scene/SceneObjectParsers.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneObjectParsers.cpp
@@ -256,7 +256,6 @@ void InitContext(SceneParseContext& context, fs::VFS& vfs, const wpscene::SceneM
         cam_para.delay                          = sc.general.cameraparallaxdelay;
         cam_para.mouse_influence                = sc.general.cameraparallaxmouseinfluence;
         context.uniform_state->CameraParallax() = cam_para;
-        context.uniform_state->SetPointerDelay(cam_para.delay);
         for (const auto& [field, key] : sc.general.user_bindings) {
             if (field == "cameraparallax" || field == "cameraparallaxamount" ||
                 field == "cameraparallaxdelay" || field == "cameraparallaxmouseinfluence") {
@@ -392,9 +391,9 @@ void ParseModelObjImpl(SceneParseContext& context, wpscene::ModelObject& model_o
     auto mesh = std::make_shared<SceneMesh>();
 
     UniformNodeConfigDraft svData;
-    svData.parallax_depth            = { model_obj.parallaxDepth[0], model_obj.parallaxDepth[1] };
-    svData.propagated_parallax_depth = { model_obj.parallaxDepth[0], model_obj.parallaxDepth[1] };
-    svData.use_camera_eye_position   = true;
+    svData.SetParallaxContract({ model_obj.parallaxDepth[0], model_obj.parallaxDepth[1] },
+                               model_obj.id);
+    svData.use_camera_eye_position = true;
     if (context.orthographic_scene) {
         svData.eye_position_override = Some(array<float, 3> {
             static_cast<float>(context.ortho_w.to_primitive()) * 0.5f,
@@ -649,13 +648,9 @@ void ParseContainerObj(SceneParseContext& context, const wpscene::ContainerObjec
                                       Vector3f(obj.angles.data()),
                                       obj.name);
     node->ID() = i32(obj.id);
-    if (obj.parallax_depth[0] != 0.0f || obj.parallax_depth[1] != 0.0f || obj.disable_propagation) {
-        UniformNodeConfigDraft uniform_config;
-        uniform_config.propagate_parallax_to_children = ! obj.disable_propagation;
-        uniform_config.parallax_depth            = { obj.parallax_depth[0], obj.parallax_depth[1] };
-        uniform_config.propagated_parallax_depth = { obj.parallax_depth[0], obj.parallax_depth[1] };
-        SetUniformConfig(context, node, rstd::move(uniform_config));
-    }
+    UniformNodeConfigDraft uniform_config;
+    uniform_config.SetParallaxContract({ obj.parallax_depth[0], obj.parallax_depth[1] }, obj.id);
+    SetUniformConfig(context, node, rstd::move(uniform_config));
     if (! obj.visible) (void)context.scene->SetNodeVisible(*node, false);
     if (! obj.visible_user.empty())
         node->SetVisibleUserBinding(ToSceneUserVisibilityBinding(obj.visible_user));

--- a/src/Scene/Pkg/Parse/Scene/SceneScriptBinding.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneScriptBinding.cpp
@@ -272,6 +272,15 @@ Option<float> ScriptValueAsFloat(const script::ScriptValue& value) {
     return None();
 }
 
+Option<array<float, 2>> ScriptValueAsVec2(const script::ScriptValue& value) {
+    auto* vector = std::get_if<script::Vec2Value>(&value);
+    if (vector == nullptr) return None();
+    return Some(array<float, 2> {
+        static_cast<float>(vector->x),
+        static_cast<float>(vector->y),
+    });
+}
+
 Option<Vector3f> ScriptValueAsVec3(const script::ScriptValue& value, const Vector3f& current) {
     Vector3f next = current;
     if (auto* p = std::get_if<script::Vec3Value>(&value)) {
@@ -375,6 +384,19 @@ void WireFieldScripts(SceneParseContext& context, const Arc<SceneNode>& node_sp,
                       std::function<void(const script::ScriptValue&)> origin_apply,
                       std::function<void(const script::ScriptValue&)> scale_apply) {
     SceneNode* node = node_sp.as_ptr();
+
+    auto parallax_user = fb.users.find("parallaxDepth");
+    if (parallax_user != fb.users.end() && node->ID() != i32() &&
+        ! context.parallax_depth_user_binding_ids.contains(node->ID())) {
+        context.parallax_depth_user_binding_ids.insert(node->ID());
+        auto state = CopyableArcHold(context.uniform_state.clone());
+        context.scene->RegisterUserPropertyBinding(
+            String::make(as_str(parallax_user->second).unwrap()),
+            Box<dyn<FnMut<void(ref<Json>)>>>::make(
+                [state, object_id = node->ID()](ref<Json> property) mutable {
+                    (void)state.value->ApplyObjectParallaxDepth(object_id, *property);
+                }));
+    }
     if (fb.scripts.empty()) return;
     auto& ss = EnsureScriptScene(context);
     auto& rt = ss.runtime();
@@ -386,6 +408,7 @@ void WireFieldScripts(SceneParseContext& context, const Arc<SceneNode>& node_sp,
         bool                        is_alpha     = false;
         bool                        is_color     = false;
         bool                        is_volume    = false;
+        bool                        is_parallax  = false;
         if (field == "origin") {
             tgt  = script::NodeTransformTarget::Translate;
             kind = script::FieldKind::Vec3;
@@ -410,6 +433,9 @@ void WireFieldScripts(SceneParseContext& context, const Arc<SceneNode>& node_sp,
         } else if (field == "volume") {
             kind      = script::FieldKind::Scalar;
             is_volume = true;
+        } else if (field == "parallaxDepth") {
+            kind        = script::FieldKind::Vec2;
+            is_parallax = true;
         } else {
             // text/rate/intensity/... are wired elsewhere or not yet supported.
             continue;
@@ -428,7 +454,15 @@ void WireFieldScripts(SceneParseContext& context, const Arc<SceneNode>& node_sp,
             ss.AddActuator({ fs, script::MakeNodeColorApply(node_sp.clone()) });
         else if (is_volume)
             ss.AddActuator({ fs, script::MakeNodeVolumeApply(node_sp.clone()) });
-        else if (field == "origin" && origin_apply)
+        else if (is_parallax) {
+            auto state = CopyableArcHold(context.uniform_state.clone());
+            ss.AddActuator(
+                { fs, [state, object_id = node->ID()](const script::ScriptValue& value) mutable {
+                     auto depth = ScriptValueAsVec2(value);
+                     if (depth.is_some())
+                         (void)state.value->SetObjectParallaxDepth(object_id, *depth);
+                 } });
+        } else if (field == "origin" && origin_apply)
             ss.AddActuator({ fs, origin_apply });
         else if (field == "scale" && scale_apply)
             ss.AddActuator({ fs, scale_apply });

--- a/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
@@ -256,8 +256,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
             node->SetVisibleUserBinding(ToSceneUserVisibilityBinding(obj.visible_user));
 
         UniformNodeConfigDraft uniform_config;
-        uniform_config.parallax_depth            = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
-        uniform_config.propagated_parallax_depth = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
+        uniform_config.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
         SetUniformConfig(context, node, rstd::move(uniform_config));
         RegisterNodeRef(context,
                         obj.id,
@@ -525,8 +524,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
     std::string                         link_output;
     if (direct_text) {
         UniformNodeConfigDraft text_sv;
-        text_sv.parallax_depth            = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
-        text_sv.propagated_parallax_depth = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
+        text_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
         SetUniformConfig(context, sp_node, rstd::move(text_sv));
     } else {
         context.text_uniform_configs.push(SceneParseContext::TextUniformConfigDraft {
@@ -628,8 +626,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
         }
 
         UniformNodeConfigDraft compose_sv;
-        compose_sv.parallax_depth            = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
-        compose_sv.propagated_parallax_depth = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
+        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
 
         ShaderValueMap effect_base = NeutralColorUniforms(context.global_base_uniforms);
 
@@ -793,12 +790,10 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
 
                     SceneMaterial          mat;
                     UniformNodeConfigDraft sv;
-                    sv.propagate_parallax_to_children = true;
-                    sv.propagated_parallax_depth = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
-                    sv.parallax_depth            = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
-                    sv.effect_projection_node    = Some(layer_node.clone());
-                    sv.effect_projection_size    = { initial_geometry.effect_frame_width,
-                                                     initial_geometry.effect_frame_height };
+                    sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
+                    sv.effect_projection_node = Some(layer_node.clone());
+                    sv.effect_projection_size = { initial_geometry.effect_frame_width,
+                                                  initial_geometry.effect_frame_height };
                     SceneShaderValueAnimationMap final_quad_shader_values;
                     auto material_result = BuildMaterial(*context.vfs,
                                                          *context.shader_cache,
@@ -907,9 +902,8 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
                       rstd::as_cast<float>(runtime_targets->layer_h) });
         auto loaded = load_passthrough_material(has_text_effect ? effect_final : composite);
         if (loaded.is_none()) return;
-        compose_sv                           = std::move(loaded->sv);
-        compose_sv.parallax_depth            = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
-        compose_sv.propagated_parallax_depth = { obj.parallaxDepth[0], obj.parallaxDepth[1] };
+        compose_sv = std::move(loaded->sv);
+        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
         compose_mesh->AddMaterial(std::move(loaded->material));
         RegisterMaterialBindings(
             scene, compose_mesh->MaterialSlots().front(), loaded->source, loaded->shader_info);

--- a/src/Scene/Pkg/Parse/Uniform/UniformSource.cpp
+++ b/src/Scene/Pkg/Parse/Uniform/UniformSource.cpp
@@ -1,5 +1,8 @@
 module;
 
+#include <algorithm>
+#include <cmath>
+
 module wescene.pkg.parse;
 import eigen;
 import owe.scene_audio_response;
@@ -191,15 +194,20 @@ auto BindEntries(mut_ref<dyn<UniformBindingSink>>            sink,
 
 } // namespace
 
+void UniformNodeConfigDraft::SetParallaxContract(array<float, 2> depth, i32 owner) {
+    object_id      = owner;
+    parallax_depth = depth;
+}
+
 auto UniformNodeConfigDraft::Clone() const -> UniformNodeConfigDraft {
     UniformNodeConfigDraft result {
-        .configured                     = configured,
-        .parallax_depth                 = parallax_depth,
-        .propagated_parallax_depth      = propagated_parallax_depth,
-        .propagate_parallax_to_children = propagate_parallax_to_children,
-        .use_camera_eye_position        = use_camera_eye_position,
-        .eye_position_override          = eye_position_override,
-        .vertices_in_world_space        = vertices_in_world_space,
+        .configured              = configured,
+        .object_id               = object_id,
+        .parallax_depth          = parallax_depth,
+        .ride_parent_parallax    = ride_parent_parallax,
+        .use_camera_eye_position = use_camera_eye_position,
+        .eye_position_override   = eye_position_override,
+        .vertices_in_world_space = vertices_in_world_space,
         .effect_projection_node =
             effect_projection_node.is_some() ? Some((*effect_projection_node).clone()) : None(),
         .effect_projection_size = effect_projection_size,
@@ -222,7 +230,18 @@ auto UniformCameraResolver::Resolve(const SceneNode& node) const -> Option<mut_r
 }
 
 void UniformSceneState::SetNodeState(SceneNodeId id, Arc<UniformNodeState> state) {
-    (void)m_nodes_by_address.insert(state->node.as_ptr().as_raw_ptr(), state.clone());
+    (void)m_nodes_by_address.insert(rstd::addressof(*state->node), state.clone());
+    if (state->object_id != i32()) {
+        if (auto current = m_object_parallax_depths.get(state->object_id); current.is_some()) {
+            state->parallax_depth = **current;
+        }
+        auto owners = m_nodes_by_object.get_mut(state->object_id);
+        if (owners.is_none()) {
+            (void)m_nodes_by_object.insert(state->object_id, Vec<Arc<UniformNodeState>>::make());
+            owners = m_nodes_by_object.get_mut(state->object_id);
+        }
+        (*owners)->push(state.clone());
+    }
     (void)m_nodes.insert(Key(id), rstd::move(state));
 }
 
@@ -233,43 +252,138 @@ bool UniformSceneState::SetEffectProjectionSize(SceneNodeId id, rstd::array<floa
     return true;
 }
 
-auto UniformSceneState::ResolveParallaxState(const UniformNodeState& state) const
-    -> const UniformNodeState& {
-    auto* resolved = rstd::addressof(state);
-    for (auto* parent = state.node->Parent(); parent != nullptr; parent = parent->Parent()) {
-        auto found = m_nodes_by_address.get(parent);
-        if (found.is_none()) continue;
-        auto& candidate = ***found;
-        if (! candidate.propagate_parallax_to_children) break;
-        resolved = rstd::addressof(candidate);
+bool UniformSceneState::SetObjectParallaxDepth(i32 object_id, array<float, 2> depth) {
+    if (auto current = m_object_parallax_depths.get_mut(object_id); current.is_some()) {
+        **current = depth;
+    } else {
+        (void)m_object_parallax_depths.insert(object_id, depth);
     }
-    return *resolved;
+    auto states = m_nodes_by_object.get_mut(object_id);
+    if (states.is_none()) return true;
+
+    // A logical layer may own a world node, private effect writers, and a detached final writer.
+    // Updating the owner group atomically keeps every pass on the same depth revision.
+    for (usize index {}; index < (*states)->len(); ++index) {
+        (**states)[index]->parallax_depth = depth;
+    }
+    return true;
+}
+
+bool UniformSceneState::ApplyObjectParallaxDepth(i32 object_id, const Json& property) {
+    const auto&     value = SceneUserPropertyPayload(property);
+    array<float, 2> depth {};
+    if (owe::GetJsonValue(value, depth)) return SetObjectParallaxDepth(object_id, depth);
+
+    auto scalar = UserScalar(property);
+    if (scalar.is_none()) return false;
+    return SetObjectParallaxDepth(object_id, { *scalar, *scalar });
+}
+
+auto UniformSceneState::FindNodeState(const SceneNode* node) const -> const UniformNodeState* {
+    if (node == nullptr) return nullptr;
+    auto found = m_nodes_by_address.get(node);
+    if (found.is_none()) return nullptr;
+    return rstd::addressof(***found);
 }
 
 void UniformSceneState::SetPointerInput(double x, double y) {
-    const auto now            = rstd::time::Instant::now();
-    const auto elapsed        = (now - m_last_pointer_input_time).as_secs_f64();
-    m_pointer_delayed_time    = std::max(0.0, m_pointer_delayed_time - elapsed);
-    m_pointer_input           = { static_cast<float>(x), static_cast<float>(y) };
-    m_last_pointer_input_time = now;
+    m_pointer_input = { static_cast<float>(x), static_cast<float>(y) };
 }
-
-void UniformSceneState::SetPointerDelay(float delay) { m_pointer_delay = std::max(0.0f, delay); }
 
 void UniformSceneState::SetAudioSpectrum(const scene_audio::Buffers& buffers) {
     m_inputs.audio = buffers;
 }
 
-void UniformSceneState::Advance(const SceneFrame& frame) {
-    const auto delay       = static_cast<double>(m_pointer_delay);
-    m_pointer_delayed_time = std::min(m_pointer_delayed_time + frame.delta.to_primitive(), delay);
-    const auto amount      = delay > 0.0 ? m_pointer_delayed_time / delay : 1.0;
+auto UniformSceneState::LogicalParallaxState(const UniformNodeState& state) const
+    -> const UniformNodeState* {
+    const UniformNodeState* current = rstd::addressof(state);
+    if (state.effect_projection_node.is_some()) {
+        if (auto* found = FindNodeState(rstd::addressof(**state.effect_projection_node));
+            found != nullptr) {
+            current = found;
+        }
+    } else if (state.object_id != i32()) {
+        auto group = m_nodes_by_object.get(state.object_id);
+        if (group.is_some()) {
+            for (usize index {}; index < (*group)->len(); ++index) {
+                const auto& candidate = (**group)[index];
+                if (candidate->node->Camera().empty()) {
+                    current = rstd::addressof(*candidate);
+                    break;
+                }
+            }
+        }
+    }
+    if (current == rstd::addressof(state) && ! state.node->Camera().empty()) {
+        for (auto* parent = state.node->Parent(); parent != nullptr; parent = parent->Parent()) {
+            if (auto* found = FindNodeState(parent);
+                found != nullptr && found->node->Camera().empty()) {
+                current = found;
+                break;
+            }
+        }
+    }
 
+    // Child layers share the unparented ancestor's parallaxDepth.
+    auto remaining = m_nodes.len();
+    while (current != nullptr && remaining != usize()) {
+        auto* next = ParentParallaxState(*current);
+        if (next == nullptr) break;
+        --remaining;
+        current = next;
+    }
+    return current;
+}
+
+auto UniformSceneState::ParentParallaxState(const UniformNodeState& current) const
+    -> const UniformNodeState* {
+    for (auto* parent = current.node->Parent(); parent != nullptr; parent = parent->Parent()) {
+        if (auto* found = FindNodeState(parent); found != nullptr) return found;
+    }
+    return nullptr;
+}
+
+auto UniformSceneState::ComputeParallaxOffset(const UniformNodeState& state,
+                                              const SceneCamera&      camera,
+                                              SceneRenderViewKind     view) const
+    -> rstd::array<float, 2> {
+    const auto* source = LogicalParallaxState(state);
+    source->node->UpdateTrans();
+    const array<float, 2> depth_values = source->parallax_depth;
+    const Vector3f node_position       = source->node->ModelTrans().block<3, 1>(0, 3).cast<float>();
+    const Vector2f depth { depth_values[usize(0)], depth_values[usize(1)] };
+    const auto     ortho_values = Ortho();
+    const Vector2f ortho { ortho_values[usize(0)], ortho_values[usize(1)] };
+    const Vector2f pointer(Inputs().pointer.data());
+    const Vector2f pointer_offset = Scaling(1.0f, -1.0f) * (Vector2f { 0.5f, 0.5f } - pointer);
+    const Vector2f mouse = pointer_offset.cwiseProduct(ortho) * CameraParallax().mouse_influence;
+    const auto     camera_position = camera.GetPosition(view).cast<float>();
+    const Vector2f offset =
+        (node_position.head<2>() - camera_position.head<2>() + mouse).cwiseProduct(depth) *
+        CameraParallax().amount;
+    return { offset.x(), offset.y() };
+}
+
+void UniformSceneState::Advance(const SceneFrame& frame) {
     m_inputs.pointer_last = m_inputs.pointer;
+    const double delay    = std::max(0.0, static_cast<double>(m_camera_parallax.delay));
+    if (delay <= 0.0) {
+        m_inputs.pointer = m_pointer_input;
+        return;
+    }
+
+    // Delay 0 snaps. Small delay stays a follow; the rate reaches 0 at 3.
+    // Delay 2 is still a follow, not a two-second time constant.
+    constexpr double kDelayRange   = 3.0;
+    constexpr double kResponseRate = 10.0;
+    const double     rate          = kResponseRate * std::max(0.0, 1.0 - delay / kDelayRange);
+    if (rate <= 0.0) return;
+
+    const double t = std::min(1.0, rate * std::max(0.0, frame.delta.to_primitive()));
     for (usize index {}; index < m_inputs.pointer.len(); ++index) {
         const auto current = m_inputs.pointer[index];
         m_inputs.pointer[index] =
-            static_cast<float>(current + (m_pointer_input[index] - current) * amount);
+            static_cast<float>(current + (m_pointer_input[index] - current) * t);
     }
 }
 
@@ -282,7 +396,6 @@ void UniformSceneState::ApplyUserProperty(std::string_view field, const Json& pr
         m_camera_parallax.amount = *value;
     } else if (field == "cameraparallaxdelay") {
         m_camera_parallax.delay = *value;
-        SetPointerDelay(*value);
     } else if (field == "cameraparallaxmouseinfluence") {
         m_camera_parallax.mouse_influence = *value;
     } else if (field == "camerashake") {
@@ -396,23 +509,16 @@ auto TransformUniformSource::Evaluate(ref<dyn<UniformUpdateContext>> context,
         auto        attached = camera.GetAttachedNode();
         const bool  own_image_effect =
             attached.is_some() && (*attached)->HasLayer() && *attached == m_node->node.as_ptr();
-        if (node.Camera() != "effect" && parallax.enable && ! own_image_effect) {
-            const auto& parallax_state = m_state->ResolveParallaxState(*m_node);
-            parallax_state.node->UpdateTrans();
-            const Vector3f node_position =
-                parallax_state.node->ModelTrans().block<3, 1>(0, 3).cast<float>();
-            const Vector2f depth(parallax_state.propagated_parallax_depth.data());
-            const auto     ortho_values = m_state->Ortho();
-            const Vector2f ortho { ortho_values[usize(0)], ortho_values[usize(1)] };
-            const Vector2f pointer(m_state->Inputs().pointer.data());
-            const Vector2f pointer_offset =
-                Scaling(1.0f, -1.0f) * (Vector2f { 0.5f, 0.5f } - pointer);
-            const Vector2f mouse = pointer_offset.cwiseProduct(ortho) * parallax.mouse_influence;
-            const auto     camera_position = camera.GetPosition(render_view).cast<float>();
-            const Vector2f shift =
-                (node_position.head<2>() - camera_position.head<2>() + mouse).cwiseProduct(depth) *
-                parallax.amount;
-            model = Affine3d(Translation3d(Vector3d(shift.x(), shift.y(), 0.0))).matrix() * model;
+        const bool apply_model_parallax =
+            node.Camera() != "effect" && parallax.enable && ! own_image_effect;
+        array<float, 2> shift {};
+        if (apply_model_parallax) {
+            shift = m_state->ComputeParallaxOffset(*m_node, camera, render_view);
+            if (shift[usize(0)] != 0.0f || shift[usize(1)] != 0.0f) {
+                model = Affine3d(Translation3d(Vector3d(shift[usize(0)], shift[usize(1)], 0.0)))
+                            .matrix() *
+                        model;
+            }
         }
 
         model *= node.GeometryTransform();
@@ -458,6 +564,15 @@ auto TransformUniformSource::Evaluate(ref<dyn<UniformUpdateContext>> context,
                                 static_cast<double>(m_node->effect_projection_size[usize(1)]) * 0.5,
                                 1.0))
                             .matrix();
+                }
+                // Screen compose can bind g_EffectModel / g_LayerModel instead of
+                // g_Model. Keep those matrices on the same shift as the layer.
+                if (apply_model_parallax && (shift[usize(0)] != 0.0f || shift[usize(1)] != 0.0f)) {
+                    const auto parallax_model =
+                        Affine3d(Translation3d(Vector3d(shift[usize(0)], shift[usize(1)], 0.0)))
+                            .matrix();
+                    layer_model  = parallax_model * layer_model;
+                    effect_model = parallax_model * effect_model;
                 }
             }
             writer.Write(Output::LayerModel, ShaderValue::fromMatrix(layer_model));

--- a/src/Scene/Pkg/Parse/Uniform/UniformSource.cppm
+++ b/src/Scene/Pkg/Parse/Uniform/UniformSource.cppm
@@ -132,8 +132,8 @@ inline auto TextureTexelOutput(std::size_t index) -> UniformOutputId {
 
 struct UniformCameraParallax {
     bool  enable { false };
-    float amount { 0.0f };
-    float delay { 0.0f };
+    float amount { 0.5f };
+    float delay { 0.1f };
     float mouse_influence { 0.0f };
 };
 
@@ -146,9 +146,9 @@ struct UniformCameraShake {
 
 struct UniformNodeConfigDraft {
     bool                    configured { false };
-    array<float, 2>         parallax_depth { 0.0f, 0.0f };
-    array<float, 2>         propagated_parallax_depth { 0.0f, 0.0f };
-    bool                    propagate_parallax_to_children { true };
+    i32                     object_id { 0 };
+    array<float, 2>         parallax_depth { 1.0f, 1.0f };
+    bool                    ride_parent_parallax { false };
     bool                    use_camera_eye_position { false };
     Option<array<float, 3>> eye_position_override;
     bool                    vertices_in_world_space { false };
@@ -156,6 +156,7 @@ struct UniformNodeConfigDraft {
     array<float, 2>         effect_projection_size { 0.0f, 0.0f };
 
     auto Clone() const -> UniformNodeConfigDraft;
+    void SetParallaxContract(array<float, 2> depth, i32 owner = i32());
 };
 
 class UniformCameraResolver {
@@ -177,8 +178,9 @@ private:
 struct UniformNodeState {
     Arc<SceneNode>             node;
     Arc<UniformCameraResolver> camera_resolver;
-    array<float, 2>            propagated_parallax_depth { 0.0f, 0.0f };
-    bool                       propagate_parallax_to_children { true };
+    i32                        object_id { 0 };
+    array<float, 2>            parallax_depth { 1.0f, 1.0f };
+    bool                       ride_parent_parallax { false };
     bool                       use_camera_eye_position { false };
     Option<array<float, 3>>    eye_position_override;
     bool                       vertices_in_world_space { false };
@@ -202,7 +204,11 @@ public:
 
     void SetNodeState(SceneNodeId, Arc<UniformNodeState>);
     bool SetEffectProjectionSize(SceneNodeId, array<float, 2>);
-    auto ResolveParallaxState(const UniformNodeState&) const -> const UniformNodeState&;
+    bool SetObjectParallaxDepth(i32, array<float, 2>);
+    bool ApplyObjectParallaxDepth(i32, const Json&);
+    auto FindNodeState(const SceneNode*) const -> const UniformNodeState*;
+    auto ComputeParallaxOffset(const UniformNodeState&, const SceneCamera&,
+                               SceneRenderViewKind) const -> array<float, 2>;
 
     UniformCameraParallax&       CameraParallax() noexcept { return m_camera_parallax; }
     const UniformCameraParallax& CameraParallax() const noexcept { return m_camera_parallax; }
@@ -213,7 +219,6 @@ public:
 
     void SetOrtho(float width, float height) { m_ortho = { width, height }; }
     void SetPointerInput(double, double);
-    void SetPointerDelay(float);
     void SetAudioSpectrum(const scene_audio::Buffers&);
     void Advance(const SceneFrame&);
     void ApplyUserProperty(std::string_view, const Json&);
@@ -230,15 +235,18 @@ private:
 
     HashMap<u64, Arc<UniformNodeState>>              m_nodes;
     HashMap<const SceneNode*, Arc<UniformNodeState>> m_nodes_by_address;
-    UniformFrameInputs                               m_inputs;
-    UniformCameraParallax                            m_camera_parallax;
-    UniformCameraShake                               m_camera_shake;
-    array<float, 2>                                  m_ortho { 1920.0f, 1080.0f };
-    array<float, 2>                                  m_pointer_input { 0.5f, 0.5f };
-    Arc<AudioResponseDemand>                         m_audio_demand;
-    float                                            m_pointer_delay { 0.0f };
-    double                                           m_pointer_delayed_time { 0.0 };
-    rstd::time::Instant m_last_pointer_input_time { rstd::time::Instant::now() };
+    HashMap<i32, Vec<Arc<UniformNodeState>>>         m_nodes_by_object;
+    HashMap<i32, array<float, 2>>                    m_object_parallax_depths;
+
+    auto LogicalParallaxState(const UniformNodeState&) const -> const UniformNodeState*;
+    auto ParentParallaxState(const UniformNodeState&) const -> const UniformNodeState*;
+
+    UniformFrameInputs       m_inputs;
+    UniformCameraParallax    m_camera_parallax;
+    UniformCameraShake       m_camera_shake;
+    array<float, 2>          m_ortho { 1920.0f, 1080.0f };
+    array<float, 2>          m_pointer_input { 0.5f, 0.5f };
+    Arc<AudioResponseDemand> m_audio_demand;
 };
 
 class UniformRuntimeInput {

--- a/src/Scene/Pkg/SceneObj/FieldBinding.cpp
+++ b/src/Scene/Pkg/SceneObj/FieldBinding.cpp
@@ -103,6 +103,7 @@ auto FieldBindings::clone() const -> FieldBindings {
         (void)result.scriptproperties.insert(field->clone(), properties->clone());
     });
     for (const auto& [field, script] : scripts) result.scripts[field] = script.clone();
+    result.users = users;
     return result;
 }
 
@@ -113,6 +114,7 @@ void FieldBindings::Update(const FieldBindings& other) {
         (void)scriptproperties.insert(field->clone(), properties->clone());
     });
     for (const auto& [field, script] : other.scripts) scripts[field] = script.clone();
+    for (const auto& [field, user] : other.users) users[field] = user;
 }
 
 std::size_t AbsorbFieldBinding(std::string_view field, const owe::Json& field_value,
@@ -132,6 +134,13 @@ std::size_t AbsorbFieldBinding(std::string_view field, const owe::Json& field_va
             ::alloc::string::String::make(rstd::cppstd::as_str(field).unwrap()),
             (*properties)->clone());
         ++count;
+    }
+    if (auto user = field_value.get("user"_str); user.is_some()) {
+        auto key = (*user)->as_str();
+        if (key.is_some()) {
+            out.users[name] = rstd::cppstd::to_string(*key);
+            ++count;
+        }
     }
     auto script = field_value.get("script"_str);
     if (script.is_some() && (*script)->is_string()) {

--- a/src/Scene/Pkg/SceneObj/FieldBinding.cppm
+++ b/src/Scene/Pkg/SceneObj/FieldBinding.cppm
@@ -77,7 +77,7 @@ bool ParseAnimOptions(const owe::Json&, AnimOptions&);
 bool ParseAnimCurve(const owe::Json&, AnimCurve&);
 
 // One captured `{value, script, scriptproperties, user}` per-field
-// binding. `source` is the inline JS module text observed in scene.json's
+// script binding. `source` is the inline JS module text observed in scene.json's
 // `"script"` key (5286 bindings, 2877 unique sources in the workshop
 // corpus — see `tests/wpscriptdump`). `properties` mirrors the per-binding
 // `scriptproperties` config block; `initial_value` is the binding's
@@ -99,6 +99,9 @@ struct FieldBindings {
     std::unordered_map<std::string, AnimCurve>     animations;
     rstd::json::Map                                scriptproperties;
     std::unordered_map<std::string, ScriptBinding> scripts;
+    // Direct `{value, user}` bindings exist without an accompanying script. Keep them independent
+    // from ScriptBinding so runtime property updates do not require manufacturing an empty script.
+    std::unordered_map<std::string, std::string> users;
 
     auto clone() const -> FieldBindings;
     void Update(const FieldBindings& other);

--- a/src/Scene/Pkg/SceneObj/ImageObject.cpp
+++ b/src/Scene/Pkg/SceneObj/ImageObject.cpp
@@ -304,14 +304,11 @@ bool ImageObject::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion v) 
     owe::GetJsonValue(json, "name", name, false);
     owe::GetJsonValue(json, "id", id, false);
     owe::GetJsonValue(json, "colorBlendMode", colorBlendMode, false);
+    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
     if (! fullscreen) {
         owe::GetJsonValue(json, "origin", origin);
         owe::GetJsonValue(json, "angles", angles);
         owe::GetJsonValue(json, "scale", scale);
-        if (! owe::GetJsonValue(json, "parallaxDepth", parallaxDepth, false) && composite_layer) {
-            // WE gives composite containers the regular layer depth when the field is omitted.
-            parallaxDepth = { 1.0f, 1.0f };
-        }
         if (jImage->get("width"_str).is_some()) {
             i32 w {}, h {};
             owe::GetJsonValue(*jImage, "width", w);
@@ -382,6 +379,7 @@ bool ShapeObject::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion v) 
     owe::GetJsonValue(json, "origin", origin);
     owe::GetJsonValue(json, "angles", angles);
     owe::GetJsonValue(json, "scale", scale);
+    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
 
     ReadImageEffects(json, vfs, v, effects);
 

--- a/src/Scene/Pkg/SceneObj/ImageObject.cppm
+++ b/src/Scene/Pkg/SceneObj/ImageObject.cppm
@@ -87,7 +87,8 @@ public:
     std::array<float, 3>     scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3>     angles { 0.0f, 0.0f, 0.0f };
     std::array<float, 2>     size { 2.0f, 2.0f };
-    std::array<float, 2>     parallaxDepth { 0.0f, 0.0f };
+    std::array<float, 2>     parallaxDepth { kDefaultParallaxDepth };
+    bool                     parallaxDepthAuthored { false };
     std::array<float, 3>     color { 1.0f, 1.0f, 1.0f };
     i32                      colorBlendMode { 0 };
     float                    alpha { 1.0f };
@@ -158,6 +159,8 @@ public:
     std::array<float, 3>     origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3>     scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3>     angles { 0.0f, 0.0f, 0.0f };
+    std::array<float, 2>     parallaxDepth { kDefaultParallaxDepth };
+    bool                     parallaxDepthAuthored { false };
     bool                     visible { true };
     std::vector<ImageEffect> effects;
 

--- a/src/Scene/Pkg/SceneObj/LightObject.cpp
+++ b/src/Scene/Pkg/SceneObj/LightObject.cpp
@@ -21,7 +21,7 @@ bool LightObject::FromJson(const owe::Json& json, fs::VFS&, SceneVersion /*v*/) 
     visible_user_key = visible_user.name;
     owe::GetJsonValue(json, "name", name, false);
     owe::GetJsonValue(json, "id", id, false);
-    owe::GetJsonValue(json, "parallaxDepth", parallaxDepth, false);
+    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
     owe::GetJsonValue(json, "shape", shape, false);
     owe::GetJsonValue(json, "locktransforms", locktransforms, false);
     owe::GetJsonValue(json, "muteineditor", muteineditor, false);

--- a/src/Scene/Pkg/SceneObj/LightObject.cppm
+++ b/src/Scene/Pkg/SceneObj/LightObject.cppm
@@ -25,7 +25,8 @@ public:
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { 0.0f, 0.0f };
+    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
+    bool                 parallaxDepthAuthored { false };
     std::array<float, 3> color { 1.0f, 1.0f, 1.0f };
     std::string          light; // "point" / "spot" / "directional" / ...
     std::string          shape; // PKGV0021+

--- a/src/Scene/Pkg/SceneObj/MiscObject.cppm
+++ b/src/Scene/Pkg/SceneObj/MiscObject.cppm
@@ -31,7 +31,8 @@ struct TextObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { 0.0f, 0.0f };
+    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
+    bool                 parallaxDepthAuthored { false };
     bool                 visible { true };
 
     bool             locktransforms { false };
@@ -89,7 +90,7 @@ struct TextObject {
         owe::GetJsonValue(json, "origin", origin, false);
         owe::GetJsonValue(json, "scale", scale, false);
         owe::GetJsonValue(json, "angles", angles, false);
-        owe::GetJsonValue(json, "parallaxDepth", parallaxDepth, false);
+        ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
         ReadVisibleProperty(json, visible, visible_user);
         visible_user_key = visible_user.name;
         owe::GetJsonValue(json, "locktransforms", locktransforms, false);
@@ -152,7 +153,8 @@ struct ModelObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { 0.0f, 0.0f };
+    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
+    bool                 parallaxDepthAuthored { false };
     bool                 visible { true };
 
     bool             locktransforms { false };
@@ -183,7 +185,7 @@ struct ModelObject {
         owe::GetJsonValue(json, "origin", origin, false);
         owe::GetJsonValue(json, "scale", scale, false);
         owe::GetJsonValue(json, "angles", angles, false);
-        owe::GetJsonValue(json, "parallaxDepth", parallaxDepth, false);
+        ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
         ReadVisibleProperty(json, visible, visible_user);
         visible_user_key = visible_user.name;
         owe::GetJsonValue(json, "locktransforms", locktransforms, false);
@@ -214,7 +216,8 @@ struct CameraObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { 0.0f, 0.0f };
+    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
+    bool                 parallaxDepthAuthored { false };
     bool                 visible { true };
 
     bool             locktransforms { false };
@@ -245,7 +248,7 @@ struct CameraObject {
         owe::GetJsonValue(json, "origin", origin, false);
         owe::GetJsonValue(json, "scale", scale, false);
         owe::GetJsonValue(json, "angles", angles, false);
-        owe::GetJsonValue(json, "parallaxDepth", parallaxDepth, false);
+        ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
         ReadVisibleProperty(json, visible, visible_user);
         visible_user_key = visible_user.name;
         owe::GetJsonValue(json, "locktransforms", locktransforms, false);

--- a/src/Scene/Pkg/SceneObj/Object.cpp
+++ b/src/Scene/Pkg/SceneObj/Object.cpp
@@ -18,7 +18,7 @@ bool ContainerObject::FromJson(const owe::Json& json) {
     owe::GetJsonValue(json, "origin", origin, false);
     owe::GetJsonValue(json, "scale", scale, false);
     owe::GetJsonValue(json, "angles", angles, false);
-    owe::GetJsonValue(json, "parallaxDepth", parallax_depth, false);
+    ReadParallaxDepth(json, parallax_depth, parallax_depth_authored);
     ReadVisibleProperty(json, visible, visible_user);
     owe::GetJsonValue(json, "solid", solid, false);
     owe::GetJsonValue(json, "disablepropagation", disable_propagation, false);

--- a/src/Scene/Pkg/SceneObj/Object.cppm
+++ b/src/Scene/Pkg/SceneObj/Object.cppm
@@ -25,7 +25,8 @@ struct ContainerObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallax_depth { 0.0f, 0.0f };
+    std::array<float, 2> parallax_depth { kDefaultParallaxDepth };
+    bool                 parallax_depth_authored { false };
     bool                 visible { true };
     bool                 solid { false };
     bool                 disable_propagation { false };

--- a/src/Scene/Pkg/SceneObj/ParticleObject.cpp
+++ b/src/Scene/Pkg/SceneObj/ParticleObject.cpp
@@ -342,6 +342,8 @@ ParticleObject ParticleObject::Clone() const {
     out.particlesrc      = particlesrc.clone();
     out.controlpoint     = controlpoint;
     out.visible_user_key = visible_user_key;
+
+    out.parallaxDepthAuthored = parallaxDepthAuthored;
     return out;
 }
 
@@ -355,7 +357,7 @@ bool ParticleObject::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion 
     owe::GetJsonValue(json, "origin", origin);
     owe::GetJsonValue(json, "angles", angles);
     owe::GetJsonValue(json, "scale", scale);
-    owe::GetJsonValue(json, "parallaxDepth", parallaxDepth, false);
+    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
 
     if (auto value = json.get("instanceoverride"_str); value.is_some() && ! (*value)->is_null()) {
         instanceoverride.FromJosn(**value);

--- a/src/Scene/Pkg/SceneObj/ParticleObject.cppm
+++ b/src/Scene/Pkg/SceneObj/ParticleObject.cppm
@@ -196,7 +196,8 @@ public:
     std::array<float, 3>     origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3>     scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3>     angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2>     parallaxDepth { 0.0f, 0.0f };
+    std::array<float, 2>     parallaxDepth { kDefaultParallaxDepth };
+    bool                     parallaxDepthAuthored { false };
     bool                     visible { true };
     std::string              particle;
     Particle                 particleObj;

--- a/src/Scene/Pkg/SceneObj/SceneDocument.cppm
+++ b/src/Scene/Pkg/SceneObj/SceneDocument.cppm
@@ -7,6 +7,7 @@ import :field_binding;
 import :visibility_binding;
 
 using namespace rstd::prelude;
+using namespace rstd::literals;
 
 export namespace owe
 
@@ -14,6 +15,24 @@ export namespace owe
 
 namespace wpscene
 {
+
+// Omitted parallaxDepth uses 1.0. Child layers follow the unparented ancestor.
+inline constexpr std::array<float, 2> kDefaultParallaxDepth { 1.0f, 1.0f };
+
+inline bool JsonHasParallaxDepth(const owe::Json& json) {
+    auto member = json.get("parallaxDepth"_str);
+    return member.is_some() && ! (*member)->is_null();
+}
+
+inline void ReadParallaxDepth(const owe::Json& json, std::array<float, 2>& depth, bool& authored) {
+    authored = JsonHasParallaxDepth(json);
+    depth    = kDefaultParallaxDepth;
+    if (authored) (void)owe::GetJsonValue(json, "parallaxDepth", depth, false);
+}
+
+inline bool IsZeroParallaxDepth(const std::array<float, 2>& depth) {
+    return depth[0] * depth[0] + depth[1] * depth[1] <= 1e-12f;
+}
 
 // pkg container version (the "PKGV00xx" stamp at the head of scene.pkg).
 // Spans 1..23 in the live corpus. Scene JSON fields are read according to
@@ -76,8 +95,8 @@ public:
     bool                 camerafade { false };
     bool                 camerapreview { false };
     bool                 cameraparallax { false };
-    float                cameraparallaxamount { 0.0f };
-    float                cameraparallaxdelay { 0.0f };
+    float                cameraparallaxamount { 0.5f };
+    float                cameraparallaxdelay { 0.1f };
     float                cameraparallaxmouseinfluence { 0.0f };
     bool                 isOrtho { false };
     Orthogonalprojection orthogonalprojection { i32(1920), i32(1080) };

--- a/src/Scene/Script/Script.cpp
+++ b/src/Scene/Script/Script.cpp
@@ -36,6 +36,7 @@ FieldKind GuessFieldKind(std::string_view field) {
     // Vec3 (position-like) fields.
     if (field == "origin" || field == "scale" || field == "angles" || field == "spriteoffset")
         return FieldKind::Vec3;
+    if (field == "parallaxDepth") return FieldKind::Vec2;
     // Color (rgb) fields.
     if (field == "color" || field == "colorn" || field == "Bg color" || field == "Bar Color" ||
         field == "Inner Color" || field == "Outer Color" || field == "Color 1" ||
@@ -45,7 +46,7 @@ FieldKind GuessFieldKind(std::string_view field) {
     // erroring; the actuator side ignores the result for MVP scope.
     if (field == "text") return FieldKind::String;
     // Everything else is a scalar: alpha, rate, intensity, fov, volume,
-    // parallaxDepth, percentage, brightness, saturation, ... .
+    // percentage, brightness, saturation, ... .
     return FieldKind::Scalar;
 }
 
@@ -144,6 +145,11 @@ ScriptValue CoerceReturn(JSContext* ctx, JSValue ret, FieldKind kind) {
         } else if (JS_IsObject(ret)) {
             read_field(ret, "x", v.x);
             read_field(ret, "y", v.y);
+        } else if (JS_IsNumber(ret)) {
+            double scalar = 0.0;
+            if (JS_ToFloat64(ctx, &scalar, ret) < 0 || ! IsFinite(scalar)) return {};
+            v.x = scalar;
+            v.y = scalar;
         } else {
             return {};
         }
@@ -294,8 +300,8 @@ JSValue ResolveConfigValue(JSContext* ctx, const Json& v) { return JsonToJs(ctx,
 // `init(value)` expects, given the bound field kind. Audio-response,
 // parallax, and color scripts all assume `value` is already a Vec2/Vec3,
 // not a raw string or array.
-//   - Numbers: passthrough for scalar; for Vec3 we splat (matching WE's
-//     "uniform scale" behaviour observed in the corpus).
+//   - Numbers: passthrough for scalar; for Vec2/Vec3 we splat (matching WE's
+//     uniform vector behaviour observed in the corpus).
 //   - Strings: WE serialises vec values as space-separated floats —
 //     "1.0 2.0 3.0" → Vec3(1,2,3). Arrays accept the same shape.
 //   - Arrays / objects with x,y[,z]: construct a Vec2 / Vec3.

--- a/tests/tests/scene-runtime/scene_runtime_tests.cpp
+++ b/tests/tests/scene-runtime/scene_runtime_tests.cpp
@@ -861,14 +861,15 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
     camera_resolver->Add(String::make("default"_str), camera.clone());
 
     auto parent_state = Arc<owe::UniformNodeState>::make(parent.clone(), camera_resolver.clone());
-    parent_state->propagated_parallax_depth      = { -1.56f, -0.79f };
-    parent_state->propagate_parallax_to_children = true;
+    parent_state->object_id      = i32(1);
+    parent_state->parallax_depth = { -1.56f, -0.79f };
     auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
-    child_state->propagated_parallax_depth      = { -1.12f, -1.36f };
-    child_state->propagate_parallax_to_children = true;
+    child_state->object_id      = i32(2);
+    child_state->parallax_depth = { 1.0f, 1.0f };
     auto effect_state = Arc<owe::UniformNodeState>::make(effect.clone(), camera_resolver.clone());
-    effect_state->propagated_parallax_depth      = { 0.0f, 0.0f };
-    effect_state->propagate_parallax_to_children = true;
+    effect_state->object_id              = i32(2);
+    effect_state->parallax_depth         = { 1.0f, 1.0f };
+    effect_state->effect_projection_node = Some(child.clone());
     state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) },
                         parent_state.clone());
     state->SetNodeState({ .index = rstd::u32(2), .generation = rstd::u32(1) }, child_state.clone());
@@ -891,17 +892,35 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
         };
     };
 
-    auto mvp             = capture_mvp();
-    auto expected_parent = expected_translation({ 1982.0f, 1053.0f }, { -1.56f, -0.79f });
+    auto mvp                = capture_mvp();
+    auto expected_inherited = expected_translation({ 1982.0f, 1053.0f }, { -1.56f, -0.79f });
     ASSERT_GT(mvp.size().to_primitive(), 13u);
-    EXPECT_NEAR(mvp[rstd::usize(12)], expected_parent.x(), 1e-5f);
-    EXPECT_NEAR(mvp[rstd::usize(13)], expected_parent.y(), 1e-5f);
+    EXPECT_NEAR(mvp[rstd::usize(12)], expected_inherited.x(), 1e-5f);
+    EXPECT_NEAR(mvp[rstd::usize(13)], expected_inherited.y(), 1e-5f);
 
-    parent_state->propagate_parallax_to_children = false;
-    mvp                                          = capture_mvp();
-    auto expected_child = expected_translation({ 1906.0f, 1050.0f }, { -1.12f, -1.36f });
-    EXPECT_NEAR(mvp[rstd::usize(12)], expected_child.x(), 1e-5f);
-    EXPECT_NEAR(mvp[rstd::usize(13)], expected_child.y(), 1e-5f);
+    child_state->parallax_depth = { 0.0f, 0.0f };
+    mvp                         = capture_mvp();
+    EXPECT_NEAR(mvp[rstd::usize(12)], expected_inherited.x(), 1e-5f);
+    EXPECT_NEAR(mvp[rstd::usize(13)], expected_inherited.y(), 1e-5f);
+
+    child_state->parallax_depth = { 0.5f, 0.5f };
+    mvp                         = capture_mvp();
+    EXPECT_NEAR(mvp[rstd::usize(12)], expected_inherited.x(), 1e-5f);
+    EXPECT_NEAR(mvp[rstd::usize(13)], expected_inherited.y(), 1e-5f);
+
+    parent_state->parallax_depth = { 0.0f, 0.0f };
+    child_state->parallax_depth  = { -0.7f, -0.7f };
+    mvp                          = capture_mvp();
+    auto expected_frozen         = expected_translation({ 1982.0f, 1053.0f }, { 0.0f, 0.0f });
+    EXPECT_NEAR(mvp[rstd::usize(12)], expected_frozen.x(), 1e-5f);
+    EXPECT_NEAR(mvp[rstd::usize(13)], expected_frozen.y(), 1e-5f);
+
+    parent_state->parallax_depth  = { 0.321f, 0.321f };
+    child_state->parallax_depth   = { 0.321f, 0.321f };
+    mvp                           = capture_mvp();
+    auto expected_parent_authored = expected_translation({ 1982.0f, 1053.0f }, { 0.321f, 0.321f });
+    EXPECT_NEAR(mvp[rstd::usize(12)], expected_parent_authored.x(), 1e-5f);
+    EXPECT_NEAR(mvp[rstd::usize(13)], expected_parent_authored.y(), 1e-5f);
 
     auto layer_camera =
         Arc<owe::SceneCamera>::make(owe::SceneCamera::MakeOrthographic(3840, 2160, -1.0, 1.0));
@@ -911,8 +930,7 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
     scene.RegisterCamera(String::make("layer"_str), layer_camera.clone());
     camera_resolver->Add(String::make("layer"_str), layer_camera.clone());
     effect->SetCamera("layer");
-    parent_state->propagate_parallax_to_children = true;
-    mvp                                          = capture_mvp();
+    mvp = capture_mvp();
     EXPECT_NEAR(mvp[rstd::usize(12)], 0.0f, 1e-5f);
     EXPECT_NEAR(mvp[rstd::usize(13)], 0.0f, 1e-5f);
 }


### PR DESCRIPTION
## Summary

Scene camera parallax was wrong in more than one place: authored `parallaxDepth` could be dropped, child layers could be computed from the wrong node, and effect / compose passes could apply a different shift than the layer itself.

This PR keeps the depth written in `scene.json`, resolves every writer of a logical layer to one parallax state, and lets user properties and scripts update that state at runtime.

## Problem

Several workshop scenes showed the same family of bugs:

- **`3409595232` (`Miku-长安雪`)**: root `DIRECTDRAW` shape `光束 - 角` writes `parallaxDepth: 0 0`. Shape parsing rebuilt it as an image with the default `1 1`. The beam sat far from the camera origin, so `g_Model` picked up a large translation even though the author turned parallax off for that layer.
- **`3363252053`**: the head is a child / bone attachment of the body, and the stars are children of the background (`0 0` under a parent at `-0.92`). Computing each leaf from its own world position or multiplying child depth (`0`, omitted `1 1`, or `-0.7`) against the parent produced a head that drifted left and stars that stayed pinned. Clock / Day sit under a HUD group at `0 0` and must stay still.
- **Effect-backed layers**: a logical layer is a world node plus private effect writers and a detached final writer. Updating or offsetting only one of them left the visible pass on a different depth, so reflections and compose blits could move while the source did not (or the reverse).

The old local / propagated depth fields could not express “this pass belongs to object N” or “children follow the unparented ancestor.”

## Contract

- Omitted `parallaxDepth` is `1 1`.
- A root layer (no parent) uses its own origin and depth. `0 0` turns that layer off.
- A child layer does not use its own depth. It follows the unparented ancestor: same offset, same depth, ancestor world position.
- Containers / empty transform parents are part of that walk; they keep a depth so a hierarchy has a controlling parent.
- Camera parallax is a model translation only (`g_Model`, and `g_LayerModel` / `g_EffectModel` when compose binds those). It is not written into `SceneNode` translation.
- Scene defaults when omitted: `cameraparallaxamount = 0.5`, `cameraparallaxdelay = 0.1`, `cameraparallaxmouseinfluence = 0.0`.
- Delay `0` snaps the pointer. Small delay stays a follow; the follow rate reaches `0` at delay `3`. Authored delay `2` is still a follow, not a two-second settle.

## Changes

- Read `parallaxDepth` through one helper for image, shape, text, model, camera, light, particle, and container objects.
- Keep a shape layer’s depth when it is converted onto the image / `DIRECTDRAW` path.
- Replace separate local / propagated depth fields with a contract of logical object id plus current depth.
- Group uniform node states by object id so world, effect, and final writers share one runtime revision.
- Resolve effect-projection and detached writers back to the logical layer, then walk to the unparented ancestor before computing the offset.
- Apply that same shift to `g_Model`, `g_LayerModel`, and `g_EffectModel` when routed compose needs those matrices.
- Skip model parallax on the layer’s own image-effect camera pass so the FBO source is not shifted twice.
- Parse direct `{ value, user }` field bindings and apply `parallaxDepth` user-property updates without a script.
- Treat scripted `parallaxDepth` as `Vec2`, including scalar-to-vector coercion, and write the whole object group.
- Advance pointer smoothing in `BeforeRender` so pointer input and uniform evaluation use the same frame.

## Result

- `3409595232`: left beam stays put; Miku keeps `0.02 0.02` and still moves.
- `3363252053`: head stays on the body, stars follow the background, Clock / Day stay on the HUD.
- Effect compose and the layer quad stay on one offset, so attachments and reflections do not split from the source.

## Test plan

- [ ] Reload `3409595232`: left beam has no camera parallax; character still moves.
- [ ] Reload `3363252053`: head stuck to body, stars follow background, Clock / Day still.
- [ ] Optional: `3462491575` text and `3492627662` morning still track the parent group, not a second leaf offset.
- [ ] Toggle user-property / script `parallaxDepth` on a multi-pass layer and confirm world + effect + final stay together.

## Verification already run

- Release build of `wescene-test` completed successfully.
- `scene-runtime-tests`: 109 passed, 0 failed, 0 skipped when run with the Wallpaper Engine asset directory as the working directory.
- `UniformSourceParallax.*`: 2 passed, 0 failed (parent routing and effect projection).
- `wescene-test rendergraph` parsed and built `3409595232` (`PKGV0021`), including the `DIRECTDRAW` light-shaft chain.
- `lito format --check` passed for 15 packages / 260 files.
- `git diff --check` passed.