### PR TITLE
scene: fix omitted parallaxDepth in perspective scenes and consolidate binding model

### DIFF
--- a/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
@@ -221,7 +221,9 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
     ApplyUserTextureBindings(context, image_wpmat);
     {
         svData.SetParallaxContract({ wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
-                                   wpimgobj.id);
+                                   wpimgobj.id,
+                                   wpimgobj.parallaxDepthAuthored,
+                                   ! wpimgobj.disablepropagation);
         if (! hasEffect && puppet.is_some() && has_bones) {
             MdlParser::AddPuppetShaderInfo(shaderInfo, **puppet);
         }
@@ -809,7 +811,9 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 SceneMaterial          material;
                 UniformNodeConfigDraft svData;
                 svData.SetParallaxContract({ wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
-                                           wpimgobj.id);
+                                           wpimgobj.id,
+                                           wpimgobj.parallaxDepthAuthored,
+                                           ! wpimgobj.disablepropagation);
                 SceneShaderValueAnimationMap final_quad_shader_values;
                 auto effect_result = BuildMaterial(vfs,
                                                    *context.shader_cache,
@@ -981,7 +985,10 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 SceneMaterial          material;
                 UniformNodeConfigDraft uniform_config;
                 uniform_config.SetParallaxContract(
-                    { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] }, wpimgobj.id);
+                    { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
+                    wpimgobj.id,
+                    wpimgobj.parallaxDepthAuthored,
+                    ! wpimgobj.disablepropagation);
                 auto material_result = BuildMaterial(vfs,
                                                      *context.shader_cache,
                                                      context.shader_environment,
@@ -1060,7 +1067,10 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                     SceneMaterial          finalMaterial;
                     UniformNodeConfigDraft finalSvData;
                     finalSvData.SetParallaxContract(
-                        { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] }, wpimgobj.id);
+                        { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
+                        wpimgobj.id,
+                        wpimgobj.parallaxDepthAuthored,
+                        ! wpimgobj.disablepropagation);
                     auto final_result = BuildMaterial(vfs,
                                                       *context.shader_cache,
                                                       context.shader_environment,

--- a/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Image/SceneImageObjectParser.cpp
@@ -220,10 +220,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
     if (color_blend_uses_layer_material && ! hasEffect) ApplyImageColorBlend(image_wpmat, wpimgobj);
     ApplyUserTextureBindings(context, image_wpmat);
     {
-        svData.SetParallaxContract({ wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
-                                   wpimgobj.id,
-                                   wpimgobj.parallaxDepthAuthored,
-                                   ! wpimgobj.disablepropagation);
+        svData.SetParallaxContract(wpimgobj.parallax, wpimgobj.id, ! wpimgobj.disablepropagation);
         if (! hasEffect && puppet.is_some() && has_bones) {
             MdlParser::AddPuppetShaderInfo(shaderInfo, **puppet);
         }
@@ -810,10 +807,7 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                     ShaderValue::fromMatrix(Eigen::Matrix4f::Identity());
                 SceneMaterial          material;
                 UniformNodeConfigDraft svData;
-                svData.SetParallaxContract({ wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
-                                           wpimgobj.id,
-                                           wpimgobj.parallaxDepthAuthored,
-                                           ! wpimgobj.disablepropagation);
+                svData.SetParallaxContract(wpimgobj.parallax, wpimgobj.id, ! wpimgobj.disablepropagation);
                 SceneShaderValueAnimationMap final_quad_shader_values;
                 auto effect_result = BuildMaterial(vfs,
                                                    *context.shader_cache,
@@ -984,11 +978,9 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                 shader_info.baseConstSvs = NeutralColorUniforms(baseConstSvs);
                 SceneMaterial          material;
                 UniformNodeConfigDraft uniform_config;
-                uniform_config.SetParallaxContract(
-                    { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
-                    wpimgobj.id,
-                    wpimgobj.parallaxDepthAuthored,
-                    ! wpimgobj.disablepropagation);
+                uniform_config.SetParallaxContract(wpimgobj.parallax,
+                                                   wpimgobj.id,
+                                                   ! wpimgobj.disablepropagation);
                 auto material_result = BuildMaterial(vfs,
                                                      *context.shader_cache,
                                                      context.shader_environment,
@@ -1066,11 +1058,9 @@ void ParseImageObjImpl(SceneParseContext& context, wpscene::ImageObject& img_obj
                     wpFinalShaderInfo.baseConstSvs = NeutralColorUniforms(baseConstSvs);
                     SceneMaterial          finalMaterial;
                     UniformNodeConfigDraft finalSvData;
-                    finalSvData.SetParallaxContract(
-                        { wpimgobj.parallaxDepth[0], wpimgobj.parallaxDepth[1] },
-                        wpimgobj.id,
-                        wpimgobj.parallaxDepthAuthored,
-                        ! wpimgobj.disablepropagation);
+                    finalSvData.SetParallaxContract(wpimgobj.parallax,
+                                                    wpimgobj.id,
+                                                    ! wpimgobj.disablepropagation);
                     auto final_result = BuildMaterial(vfs,
                                                       *context.shader_cache,
                                                       context.shader_environment,
@@ -1216,8 +1206,7 @@ void ParseShapeObj(SceneParseContext& context, wpscene::ShapeObject& shape_obj) 
     image.field_bindings        = rstd::move(shape_obj.field_bindings);
     image.visible_user          = rstd::move(shape_obj.visible_user);
     image.visible_user_key      = rstd::move(shape_obj.visible_user_key);
-    image.parallaxDepth         = shape_obj.parallaxDepth;
-    image.parallaxDepthAuthored = shape_obj.parallaxDepthAuthored;
+    image.parallax              = shape_obj.parallax;
     ParseImageObjImpl(context,
                       image,
                       ImageParseGeometry {

--- a/src/Scene/Pkg/Parse/Particle/SceneParticleObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Particle/SceneParticleObjectParser.cpp
@@ -402,9 +402,7 @@ void BuildParticleObjectNode(ParticleObjectParseServices& services,
     UniformNodeConfigDraft svData;
 
     if (! is_child) {
-        svData.SetParallaxContract({ wppartobj.parallaxDepth[0], wppartobj.parallaxDepth[1] },
-                                   wppartobj.id,
-                                   wppartobj.parallaxDepthAuthored);
+        svData.SetParallaxContract(wppartobj.parallax, wppartobj.id);
     }
     svData.use_camera_eye_position = particle_obj.flags[wpscene::Particle::FlagEnum::perspective];
     svData.vertices_in_world_space = particle_obj.flags[wpscene::Particle::FlagEnum::wordspace];

--- a/src/Scene/Pkg/Parse/Particle/SceneParticleObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Particle/SceneParticleObjectParser.cpp
@@ -403,7 +403,8 @@ void BuildParticleObjectNode(ParticleObjectParseServices& services,
 
     if (! is_child) {
         svData.SetParallaxContract({ wppartobj.parallaxDepth[0], wppartobj.parallaxDepth[1] },
-                                   wppartobj.id);
+                                   wppartobj.id,
+                                   wppartobj.parallaxDepthAuthored);
     }
     svData.use_camera_eye_position = particle_obj.flags[wpscene::Particle::FlagEnum::perspective];
     svData.vertices_in_world_space = particle_obj.flags[wpscene::Particle::FlagEnum::wordspace];

--- a/src/Scene/Pkg/Parse/Scene/SceneContext.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneContext.cpp
@@ -8,10 +8,7 @@ void owe::SetUniformConfig(SceneParseContext& context, const Arc<SceneNode>& nod
                            UniformNodeConfigDraft config) {
     config.configured = true;
     context.uniform_state->RegisterNodeParallaxContract(
-        *node,
-        config.object_id,
-        config.parallax_depth,
-        config.parallax_depth_authored);
+        *node, config.object_id, config.parallax);
     for (auto& entry : context.uniform_configs) {
         if (entry.node.as_ptr() != node.as_ptr()) continue;
         entry.config = rstd::move(config);
@@ -29,6 +26,17 @@ auto owe::FindUniformConfig(const SceneParseContext& context, const SceneNode& n
         if (entry.node.as_ptr() == &node) return &entry.config;
     }
     return nullptr;
+}
+
+void owe::ApplyParallaxUniformConfig(SceneParseContext&                    context,
+                                const Arc<SceneNode>&                 node,
+                                const wpscene::ParallaxDepthBinding&  parallax,
+                                i32                                   object_id,
+                                bool                                  propagate_to_children) {
+    if (! parallax.authored && wpscene::IsZeroParallaxDepth(parallax.depth)) return;
+    UniformNodeConfigDraft uniform_config;
+    uniform_config.SetParallaxContract(parallax, object_id, propagate_to_children);
+    SetUniformConfig(context, node, rstd::move(uniform_config));
 }
 
 auto owe::SceneParseContext::NextSyntheticObjectId() -> i32 {

--- a/src/Scene/Pkg/Parse/Scene/SceneContext.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneContext.cpp
@@ -8,7 +8,10 @@ void owe::SetUniformConfig(SceneParseContext& context, const Arc<SceneNode>& nod
                            UniformNodeConfigDraft config) {
     config.configured = true;
     context.uniform_state->RegisterNodeParallaxContract(
-        *node, config.object_id, config.parallax_depth);
+        *node,
+        config.object_id,
+        config.parallax_depth,
+        config.parallax_depth_authored);
     for (auto& entry : context.uniform_configs) {
         if (entry.node.as_ptr() != node.as_ptr()) continue;
         entry.config = rstd::move(config);

--- a/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
+++ b/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
@@ -295,10 +295,13 @@ struct ProcessOpts {
 
 SceneParseContext BuildContext(fs::VFS&, ref<str> scene_id, const wpscene::SceneMetadata&,
                                array<i32, 2>                ortho_extent,
+                               bool                         any_authored_parallax,
                                Option<ref<rstd::json::Map>> user_properties    = None(),
                                Option<rstd::path::PathBuf>  shader_cache_dir   = None(),
                                GeometryShaderLimits         geometry_limits    = {},
                                bool                         directional_shadow = false);
+
+bool SceneHasAuthoredParallaxDepth(slice<SceneObjectVar> objects);
 
 void IndexSceneDocument(SceneParseContext&, ref<wpscene::SceneDocument>, slice<SceneObjectVar>);
 void ProcessContainers(SceneParseContext&, mut_ref<SceneObjectVar[]>);

--- a/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
+++ b/src/Scene/Pkg/Parse/Scene/SceneContext.cppm
@@ -191,6 +191,11 @@ struct SceneParseContext {
 };
 
 void SetUniformConfig(SceneParseContext&, const Arc<SceneNode>&, UniformNodeConfigDraft);
+void ApplyParallaxUniformConfig(SceneParseContext&,
+                                const Arc<SceneNode>&,
+                                const wpscene::ParallaxDepthBinding& parallax,
+                                i32                                   object_id,
+                                bool                                  propagate_to_children = true);
 auto FindUniformConfig(const SceneParseContext&, const SceneNode&) -> const UniformNodeConfigDraft*;
 void RegisterNodeRef(SceneParseContext&, i32, SceneParseContext::NodeRef);
 

--- a/src/Scene/Pkg/Parse/Scene/SceneFinalize.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneFinalize.cpp
@@ -47,10 +47,12 @@ bool RegisterUniformNodeSources(Scene& scene, const Arc<UniformSceneState>& unif
     auto node_id = scene.ResourceIndex().nodeId(*node);
     if (node_id.is_none()) return false;
 
-    auto state            = Arc<UniformNodeState>::make(node.clone(), camera_resolver.clone());
-    state->object_id      = config.object_id;
-    state->parallax_depth = config.parallax_depth;
-    state->ride_parent_parallax    = config.ride_parent_parallax;
+    auto state                         = Arc<UniformNodeState>::make(node.clone(), camera_resolver.clone());
+    state->object_id                   = config.object_id;
+    state->parallax_depth              = config.parallax_depth;
+    state->parallax_depth_authored     = config.parallax_depth_authored;
+    state->propagate_parallax_to_children = config.propagate_parallax_to_children;
+    state->ride_parent_parallax        = config.ride_parent_parallax;
     state->use_camera_eye_position = config.use_camera_eye_position;
     state->eye_position_override   = config.eye_position_override;
     state->vertices_in_world_space = config.vertices_in_world_space;

--- a/src/Scene/Pkg/Parse/Scene/SceneFinalize.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneFinalize.cpp
@@ -49,8 +49,7 @@ bool RegisterUniformNodeSources(Scene& scene, const Arc<UniformSceneState>& unif
 
     auto state                         = Arc<UniformNodeState>::make(node.clone(), camera_resolver.clone());
     state->object_id                   = config.object_id;
-    state->parallax_depth              = config.parallax_depth;
-    state->parallax_depth_authored     = config.parallax_depth_authored;
+    state->parallax                    = config.parallax;
     state->propagate_parallax_to_children = config.propagate_parallax_to_children;
     state->ride_parent_parallax        = config.ride_parent_parallax;
     state->use_camera_eye_position = config.use_camera_eye_position;

--- a/src/Scene/Pkg/Parse/Scene/SceneObjectParsers.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneObjectParsers.cpp
@@ -197,7 +197,7 @@ void ParseCameraObj(SceneParseContext& context, wpscene::CameraObject& cam) {
 }
 
 void InitContext(SceneParseContext& context, fs::VFS& vfs, const wpscene::SceneMetadata& sc,
-                 array<i32, 2> ortho_extent) {
+                 array<i32, 2> ortho_extent, bool any_authored_parallax) {
     context.vfs = &vfs;
     auto& scene = *context.scene;
     scene.SetImageParser(Box<dyn<IImageParser>>::make(TexImageParser(&vfs)));
@@ -214,6 +214,8 @@ void InitContext(SceneParseContext& context, fs::VFS& vfs, const wpscene::SceneM
     context.ortho_w            = ortho_extent[usize()];
     context.ortho_h            = ortho_extent[usize(1)];
     context.orthographic_scene = sc.general.isOrtho;
+    context.uniform_state->SetLayerParallaxPolicy(sc.general.isOrtho || any_authored_parallax,
+                                                  sc.general.isOrtho);
 
     {
         auto& gb                                   = context.global_base_uniforms;
@@ -392,7 +394,8 @@ void ParseModelObjImpl(SceneParseContext& context, wpscene::ModelObject& model_o
 
     UniformNodeConfigDraft svData;
     svData.SetParallaxContract({ model_obj.parallaxDepth[0], model_obj.parallaxDepth[1] },
-                               model_obj.id);
+                               model_obj.id,
+                               model_obj.parallaxDepthAuthored);
     svData.use_camera_eye_position = true;
     if (context.orthographic_scene) {
         svData.eye_position_override = Some(array<float, 3> {
@@ -552,6 +555,40 @@ void ParseModelObj(SceneParseContext& context, wpscene::ModelObject& model) {
     ParseModelObjImpl(context, model);
 }
 
+bool SceneHasAuthoredParallaxDepth(slice<SceneObjectVar> objects) {
+    for (usize index {}; index < objects.len(); ++index) {
+        const auto& object = objects[index];
+        RSTD_MATCH(object) {
+            RSTD_CASE(Container, value) {
+                if (value.parallax_depth_authored) return true;
+            }
+            RSTD_CASE(Image, value) {
+                if (value.parallaxDepthAuthored) return true;
+            }
+            RSTD_CASE(Shape, value) {
+                if (value.parallaxDepthAuthored) return true;
+            }
+            RSTD_CASE(Particle, value) {
+                if (value.parallaxDepthAuthored) return true;
+            }
+            RSTD_CASE(Light, value) {
+                if (value.parallaxDepthAuthored) return true;
+            }
+            RSTD_CASE(Text, value) {
+                if (value.parallaxDepthAuthored) return true;
+            }
+            RSTD_CASE(Model, value) {
+                if (value.parallaxDepthAuthored) return true;
+            }
+            RSTD_CASE(Camera, value) {
+                if (value.parallaxDepthAuthored) return true;
+            }
+            RSTD_CASE(Sound) { continue; }
+        }
+    }
+    return false;
+}
+
 void IndexSceneDocument(SceneParseContext& context, ref<wpscene::SceneDocument> document,
                         slice<SceneObjectVar> objects) {
     context.scene_has_scripts       = SceneHasScripts(objects);
@@ -570,11 +607,12 @@ void IndexSceneDocument(SceneParseContext& context, ref<wpscene::SceneDocument> 
 
 SceneParseContext BuildContext(fs::VFS& vfs, ref<str> scene_id, const wpscene::SceneMetadata& sc,
                                array<i32, 2>                ortho_extent,
+                               bool                         any_authored_parallax,
                                Option<ref<rstd::json::Map>> user_properties,
                                Option<rstd::path::PathBuf>  shader_cache_dir,
                                GeometryShaderLimits geometry_limits, bool directional_shadow) {
     SceneParseContext context;
-    InitContext(context, vfs, sc, ortho_extent);
+    InitContext(context, vfs, sc, ortho_extent, any_authored_parallax);
     ParseCamera(context, sc);
     context.pkg_version            = sc.pkg_version;
     context.user_properties        = user_properties;
@@ -648,9 +686,15 @@ void ParseContainerObj(SceneParseContext& context, const wpscene::ContainerObjec
                                       Vector3f(obj.angles.data()),
                                       obj.name);
     node->ID() = i32(obj.id);
-    UniformNodeConfigDraft uniform_config;
-    uniform_config.SetParallaxContract({ obj.parallax_depth[0], obj.parallax_depth[1] }, obj.id);
-    SetUniformConfig(context, node, rstd::move(uniform_config));
+    if (obj.parallax_depth_authored || obj.disable_propagation ||
+        ! wpscene::IsZeroParallaxDepth(obj.parallax_depth)) {
+        UniformNodeConfigDraft uniform_config;
+        uniform_config.SetParallaxContract({ obj.parallax_depth[0], obj.parallax_depth[1] },
+                                             obj.id,
+                                             obj.parallax_depth_authored,
+                                             ! obj.disable_propagation);
+        SetUniformConfig(context, node, rstd::move(uniform_config));
+    }
     if (! obj.visible) (void)context.scene->SetNodeVisible(*node, false);
     if (! obj.visible_user.empty())
         node->SetVisibleUserBinding(ToSceneUserVisibilityBinding(obj.visible_user));

--- a/src/Scene/Pkg/Parse/Scene/SceneObjectParsers.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneObjectParsers.cpp
@@ -393,9 +393,7 @@ void ParseModelObjImpl(SceneParseContext& context, wpscene::ModelObject& model_o
     auto mesh = std::make_shared<SceneMesh>();
 
     UniformNodeConfigDraft svData;
-    svData.SetParallaxContract({ model_obj.parallaxDepth[0], model_obj.parallaxDepth[1] },
-                               model_obj.id,
-                               model_obj.parallaxDepthAuthored);
+    svData.SetParallaxContract(model_obj.parallax, model_obj.id);
     svData.use_camera_eye_position = true;
     if (context.orthographic_scene) {
         svData.eye_position_override = Some(array<float, 3> {
@@ -557,34 +555,7 @@ void ParseModelObj(SceneParseContext& context, wpscene::ModelObject& model) {
 
 bool SceneHasAuthoredParallaxDepth(slice<SceneObjectVar> objects) {
     for (usize index {}; index < objects.len(); ++index) {
-        const auto& object = objects[index];
-        RSTD_MATCH(object) {
-            RSTD_CASE(Container, value) {
-                if (value.parallax_depth_authored) return true;
-            }
-            RSTD_CASE(Image, value) {
-                if (value.parallaxDepthAuthored) return true;
-            }
-            RSTD_CASE(Shape, value) {
-                if (value.parallaxDepthAuthored) return true;
-            }
-            RSTD_CASE(Particle, value) {
-                if (value.parallaxDepthAuthored) return true;
-            }
-            RSTD_CASE(Light, value) {
-                if (value.parallaxDepthAuthored) return true;
-            }
-            RSTD_CASE(Text, value) {
-                if (value.parallaxDepthAuthored) return true;
-            }
-            RSTD_CASE(Model, value) {
-                if (value.parallaxDepthAuthored) return true;
-            }
-            RSTD_CASE(Camera, value) {
-                if (value.parallaxDepthAuthored) return true;
-            }
-            RSTD_CASE(Sound) { continue; }
-        }
+        if (wpscene::SceneObjectParallaxAuthored(objects[index])) return true;
     }
     return false;
 }
@@ -686,14 +657,9 @@ void ParseContainerObj(SceneParseContext& context, const wpscene::ContainerObjec
                                       Vector3f(obj.angles.data()),
                                       obj.name);
     node->ID() = i32(obj.id);
-    if (obj.parallax_depth_authored || obj.disable_propagation ||
-        ! wpscene::IsZeroParallaxDepth(obj.parallax_depth)) {
-        UniformNodeConfigDraft uniform_config;
-        uniform_config.SetParallaxContract({ obj.parallax_depth[0], obj.parallax_depth[1] },
-                                             obj.id,
-                                             obj.parallax_depth_authored,
-                                             ! obj.disable_propagation);
-        SetUniformConfig(context, node, rstd::move(uniform_config));
+    if (obj.parallax.authored || obj.disable_propagation ||
+        ! wpscene::IsZeroParallaxDepth(obj.parallax.depth)) {
+        ApplyParallaxUniformConfig(context, node, obj.parallax, obj.id, ! obj.disable_propagation);
     }
     if (! obj.visible) (void)context.scene->SetNodeVisible(*node, false);
     if (! obj.visible_user.empty())

--- a/src/Scene/Pkg/Parse/Scene/SceneParser.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneParser.cpp
@@ -51,11 +51,13 @@ auto owe::SceneParser::Parse(ref<str> scene_id, ref<wpscene::SceneDocument> docu
     }
 
     auto context_span = SceneLoadSpan(options.load_bench, &SceneLoadProbeIds::parse_context);
+    const bool any_authored_parallax = SceneHasAuthoredParallaxDepth(objects.as_slice());
     auto context =
         BuildContext(vfs_owner,
                      scene_id,
                      metadata,
                      ResolveOrthoProjectionExtent(metadata, objects.as_slice()),
+                     any_authored_parallax,
                      options.user_properties,
                      rstd::move(options.shader_cache_dir),
                      GeometryShaderLimits {

--- a/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
@@ -256,7 +256,9 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
             node->SetVisibleUserBinding(ToSceneUserVisibilityBinding(obj.visible_user));
 
         UniformNodeConfigDraft uniform_config;
-        uniform_config.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
+        uniform_config.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
+                                             obj.id,
+                                             obj.parallaxDepthAuthored);
         SetUniformConfig(context, node, rstd::move(uniform_config));
         RegisterNodeRef(context,
                         obj.id,
@@ -524,7 +526,9 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
     std::string                         link_output;
     if (direct_text) {
         UniformNodeConfigDraft text_sv;
-        text_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
+        text_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
+                                    obj.id,
+                                    obj.parallaxDepthAuthored);
         SetUniformConfig(context, sp_node, rstd::move(text_sv));
     } else {
         context.text_uniform_configs.push(SceneParseContext::TextUniformConfigDraft {
@@ -626,7 +630,9 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
         }
 
         UniformNodeConfigDraft compose_sv;
-        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
+        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
+                                       obj.id,
+                                       obj.parallaxDepthAuthored);
 
         ShaderValueMap effect_base = NeutralColorUniforms(context.global_base_uniforms);
 
@@ -790,7 +796,9 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
 
                     SceneMaterial          mat;
                     UniformNodeConfigDraft sv;
-                    sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
+                    sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
+                                           obj.id,
+                                           obj.parallaxDepthAuthored);
                     sv.effect_projection_node = Some(layer_node.clone());
                     sv.effect_projection_size = { initial_geometry.effect_frame_width,
                                                   initial_geometry.effect_frame_height };
@@ -903,7 +911,9 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
         auto loaded = load_passthrough_material(has_text_effect ? effect_final : composite);
         if (loaded.is_none()) return;
         compose_sv = std::move(loaded->sv);
-        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] }, obj.id);
+        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
+                                       obj.id,
+                                       obj.parallaxDepthAuthored);
         compose_mesh->AddMaterial(std::move(loaded->material));
         RegisterMaterialBindings(
             scene, compose_mesh->MaterialSlots().front(), loaded->source, loaded->shader_info);

--- a/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
+++ b/src/Scene/Pkg/Parse/Scene/SceneTextObjectParser.cpp
@@ -255,11 +255,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
         if (! obj.visible_user.empty())
             node->SetVisibleUserBinding(ToSceneUserVisibilityBinding(obj.visible_user));
 
-        UniformNodeConfigDraft uniform_config;
-        uniform_config.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
-                                             obj.id,
-                                             obj.parallaxDepthAuthored);
-        SetUniformConfig(context, node, rstd::move(uniform_config));
+        ApplyParallaxUniformConfig(context, node, obj.parallax, obj.id);
         RegisterNodeRef(context,
                         obj.id,
                         SceneParseContext::NodeRef {
@@ -526,9 +522,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
     std::string                         link_output;
     if (direct_text) {
         UniformNodeConfigDraft text_sv;
-        text_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
-                                    obj.id,
-                                    obj.parallaxDepthAuthored);
+        text_sv.SetParallaxContract(obj.parallax, obj.id);
         SetUniformConfig(context, sp_node, rstd::move(text_sv));
     } else {
         context.text_uniform_configs.push(SceneParseContext::TextUniformConfigDraft {
@@ -630,9 +624,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
         }
 
         UniformNodeConfigDraft compose_sv;
-        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
-                                       obj.id,
-                                       obj.parallaxDepthAuthored);
+        compose_sv.SetParallaxContract(obj.parallax, obj.id);
 
         ShaderValueMap effect_base = NeutralColorUniforms(context.global_base_uniforms);
 
@@ -796,9 +788,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
 
                     SceneMaterial          mat;
                     UniformNodeConfigDraft sv;
-                    sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
-                                           obj.id,
-                                           obj.parallaxDepthAuthored);
+                    sv.SetParallaxContract(obj.parallax, obj.id);
                     sv.effect_projection_node = Some(layer_node.clone());
                     sv.effect_projection_size = { initial_geometry.effect_frame_width,
                                                   initial_geometry.effect_frame_height };
@@ -911,9 +901,7 @@ void ParseTextObjImpl(SceneParseContext& context, wpscene::TextObject& obj) {
         auto loaded = load_passthrough_material(has_text_effect ? effect_final : composite);
         if (loaded.is_none()) return;
         compose_sv = std::move(loaded->sv);
-        compose_sv.SetParallaxContract({ obj.parallaxDepth[0], obj.parallaxDepth[1] },
-                                       obj.id,
-                                       obj.parallaxDepthAuthored);
+        compose_sv.SetParallaxContract(obj.parallax, obj.id);
         compose_mesh->AddMaterial(std::move(loaded->material));
         RegisterMaterialBindings(
             scene, compose_mesh->MaterialSlots().front(), loaded->source, loaded->shader_info);

--- a/src/Scene/Pkg/Parse/Uniform/UniformSource.cpp
+++ b/src/Scene/Pkg/Parse/Uniform/UniformSource.cpp
@@ -194,20 +194,25 @@ auto BindEntries(mut_ref<dyn<UniformBindingSink>>            sink,
 
 } // namespace
 
-void UniformNodeConfigDraft::SetParallaxContract(array<float, 2> depth, i32 owner) {
-    object_id      = owner;
-    parallax_depth = depth;
+void UniformNodeConfigDraft::SetParallaxContract(array<float, 2> depth, i32 owner, bool authored,
+                                                 bool propagate_to_children) {
+    object_id                       = owner;
+    parallax_depth                  = depth;
+    parallax_depth_authored         = authored;
+    propagate_parallax_to_children  = propagate_to_children;
 }
 
 auto UniformNodeConfigDraft::Clone() const -> UniformNodeConfigDraft {
     UniformNodeConfigDraft result {
-        .configured              = configured,
-        .object_id               = object_id,
-        .parallax_depth          = parallax_depth,
-        .ride_parent_parallax    = ride_parent_parallax,
-        .use_camera_eye_position = use_camera_eye_position,
-        .eye_position_override   = eye_position_override,
-        .vertices_in_world_space = vertices_in_world_space,
+        .configured                     = configured,
+        .object_id                      = object_id,
+        .parallax_depth                 = parallax_depth,
+        .parallax_depth_authored        = parallax_depth_authored,
+        .propagate_parallax_to_children = propagate_parallax_to_children,
+        .ride_parent_parallax           = ride_parent_parallax,
+        .use_camera_eye_position        = use_camera_eye_position,
+        .eye_position_override          = eye_position_override,
+        .vertices_in_world_space        = vertices_in_world_space,
         .effect_projection_node =
             effect_projection_node.is_some() ? Some((*effect_projection_node).clone()) : None(),
         .effect_projection_size = effect_projection_size,
@@ -236,7 +241,10 @@ auto UniformCameraResolver::Resolve(const SceneNode& node) const -> Option<mut_r
 }
 
 void UniformSceneState::SetNodeState(SceneNodeId id, Arc<UniformNodeState> state) {
-    RegisterNodeParallaxContract(*state->node, state->object_id, state->parallax_depth);
+    RegisterNodeParallaxContract(*state->node,
+                                 state->object_id,
+                                 state->parallax_depth,
+                                 state->parallax_depth_authored);
     (void)m_nodes_by_address.insert(rstd::addressof(*state->node), state.clone());
     if (state->object_id != i32()) {
         if (auto current = m_object_parallax_depths.get(state->object_id); current.is_some()) {
@@ -255,8 +263,9 @@ void UniformSceneState::SetNodeState(SceneNodeId id, Arc<UniformNodeState> state
 }
 
 void UniformSceneState::RegisterNodeParallaxContract(const SceneNode& node, i32 object_id,
-                                                     array<float, 2> depth) {
+                                                     array<float, 2> depth, bool authored) {
     (void)m_parallax_owners.insert(rstd::addressof(node), object_id);
+    if (! authored) return;
     if (object_id != i32()) {
         if (! m_object_parallax_depths.contains_key(object_id))
             (void)m_object_parallax_depths.insert(object_id, depth);
@@ -285,7 +294,8 @@ bool UniformSceneState::SetObjectParallaxDepth(i32 object_id, array<float, 2> de
     // A logical layer may own a world node, private effect writers, and a detached final writer.
     // Updating the owner group atomically keeps every pass on the same depth revision.
     for (usize index {}; index < (*states)->len(); ++index) {
-        (**states)[index]->parallax_depth = depth;
+        (**states)[index]->parallax_depth         = depth;
+        (**states)[index]->parallax_depth_authored = true;
     }
     return true;
 }
@@ -300,7 +310,10 @@ bool UniformSceneState::SetNodeParallaxDepth(const SceneNode& node, array<float,
         (void)m_node_parallax_depths.insert(rstd::addressof(node), depth);
     }
     auto state = m_nodes_by_address.get(rstd::addressof(node));
-    if (state.is_some()) (**state)->parallax_depth = depth;
+    if (state.is_some()) {
+        (**state)->parallax_depth         = depth;
+        (**state)->parallax_depth_authored = true;
+    }
     return owner.is_some() || state.is_some();
 }
 
@@ -372,13 +385,17 @@ auto UniformSceneState::LogicalParallaxState(const UniformNodeState& state) cons
         }
     }
 
-    // Child layers share the unparented ancestor's parallaxDepth.
+    if (current->parallax_depth_authored) return current;
+
+    // Unauthored layers inherit from the nearest authored ancestor.
     auto remaining = m_nodes.len();
-    while (current != nullptr && remaining != usize()) {
-        auto* next = ParentParallaxState(*current);
-        if (next == nullptr) break;
+    while (remaining != usize()) {
+        auto* parent = ParentParallaxState(*current);
+        if (parent == nullptr) break;
         --remaining;
-        current = next;
+        if (! parent->propagate_parallax_to_children) break;
+        current = parent;
+        if (current->parallax_depth_authored) return current;
     }
     return current;
 }
@@ -395,9 +412,22 @@ auto UniformSceneState::ComputeParallaxOffset(const UniformNodeState& state,
                                               const SceneCamera&      camera,
                                               SceneRenderViewKind     view) const
     -> rstd::array<float, 2> {
+    if (! m_layer_parallax_enabled) return { 0.0f, 0.0f };
+
     const auto* source = LogicalParallaxState(state);
+
+    array<float, 2> depth_values;
+    if (source->parallax_depth_authored) {
+        depth_values = source->parallax_depth;
+        if (wpscene::IsZeroParallaxDepth(depth_values)) return { 0.0f, 0.0f };
+    } else if (m_orthographic_implicit_parallax) {
+        depth_values = { wpscene::kImplicitOrthographicParallaxDepth[0],
+                         wpscene::kImplicitOrthographicParallaxDepth[1] };
+    } else {
+        return { 0.0f, 0.0f };
+    }
+
     source->node->UpdateTrans();
-    const array<float, 2> depth_values = source->parallax_depth;
     const Vector3f node_position       = source->node->ModelTrans().block<3, 1>(0, 3).cast<float>();
     const Vector2f depth { depth_values[usize(0)], depth_values[usize(1)] };
     const auto     ortho_values = Ortho();

--- a/src/Scene/Pkg/Parse/Uniform/UniformSource.cpp
+++ b/src/Scene/Pkg/Parse/Uniform/UniformSource.cpp
@@ -194,20 +194,18 @@ auto BindEntries(mut_ref<dyn<UniformBindingSink>>            sink,
 
 } // namespace
 
-void UniformNodeConfigDraft::SetParallaxContract(array<float, 2> depth, i32 owner, bool authored,
+void UniformNodeConfigDraft::SetParallaxContract(wpscene::ParallaxDepthBinding binding, i32 owner,
                                                  bool propagate_to_children) {
-    object_id                       = owner;
-    parallax_depth                  = depth;
-    parallax_depth_authored         = authored;
-    propagate_parallax_to_children  = propagate_to_children;
+    object_id                      = owner;
+    parallax                       = rstd::move(binding);
+    propagate_parallax_to_children = propagate_to_children;
 }
 
 auto UniformNodeConfigDraft::Clone() const -> UniformNodeConfigDraft {
     UniformNodeConfigDraft result {
         .configured                     = configured,
         .object_id                      = object_id,
-        .parallax_depth                 = parallax_depth,
-        .parallax_depth_authored        = parallax_depth_authored,
+        .parallax                       = parallax,
         .propagate_parallax_to_children = propagate_parallax_to_children,
         .ride_parent_parallax           = ride_parent_parallax,
         .use_camera_eye_position        = use_camera_eye_position,
@@ -241,14 +239,12 @@ auto UniformCameraResolver::Resolve(const SceneNode& node) const -> Option<mut_r
 }
 
 void UniformSceneState::SetNodeState(SceneNodeId id, Arc<UniformNodeState> state) {
-    RegisterNodeParallaxContract(*state->node,
-                                 state->object_id,
-                                 state->parallax_depth,
-                                 state->parallax_depth_authored);
+    RegisterNodeParallaxContract(*state->node, state->object_id, state->parallax);
     (void)m_nodes_by_address.insert(rstd::addressof(*state->node), state.clone());
     if (state->object_id != i32()) {
         if (auto current = m_object_parallax_depths.get(state->object_id); current.is_some()) {
-            state->parallax_depth = **current;
+            state->parallax.depth    = { (**current)[usize()], (**current)[usize(1)] };
+            state->parallax.authored = true;
         }
         auto owners = m_nodes_by_object.get_mut(state->object_id);
         if (owners.is_none()) {
@@ -257,15 +253,18 @@ void UniformSceneState::SetNodeState(SceneNodeId id, Arc<UniformNodeState> state
         }
         (*owners)->push(state.clone());
     } else if (auto current = m_node_parallax_depths.get(state->node.as_ptr()); current.is_some()) {
-        state->parallax_depth = **current;
+        state->parallax.depth    = { (**current)[usize()], (**current)[usize(1)] };
+        state->parallax.authored = true;
     }
     (void)m_nodes.insert(Key(id), rstd::move(state));
 }
 
-void UniformSceneState::RegisterNodeParallaxContract(const SceneNode& node, i32 object_id,
-                                                     array<float, 2> depth, bool authored) {
+void UniformSceneState::RegisterNodeParallaxContract(const SceneNode&           node,
+                                                     i32                        object_id,
+                                                     const wpscene::ParallaxDepthBinding& binding) {
     (void)m_parallax_owners.insert(rstd::addressof(node), object_id);
-    if (! authored) return;
+    if (! binding.authored) return;
+    const array<float, 2> depth { binding.depth[0], binding.depth[1] };
     if (object_id != i32()) {
         if (! m_object_parallax_depths.contains_key(object_id))
             (void)m_object_parallax_depths.insert(object_id, depth);
@@ -294,8 +293,8 @@ bool UniformSceneState::SetObjectParallaxDepth(i32 object_id, array<float, 2> de
     // A logical layer may own a world node, private effect writers, and a detached final writer.
     // Updating the owner group atomically keeps every pass on the same depth revision.
     for (usize index {}; index < (*states)->len(); ++index) {
-        (**states)[index]->parallax_depth         = depth;
-        (**states)[index]->parallax_depth_authored = true;
+        (**states)[index]->parallax.depth    = { depth[usize()], depth[usize(1)] };
+        (**states)[index]->parallax.authored = true;
     }
     return true;
 }
@@ -311,8 +310,8 @@ bool UniformSceneState::SetNodeParallaxDepth(const SceneNode& node, array<float,
     }
     auto state = m_nodes_by_address.get(rstd::addressof(node));
     if (state.is_some()) {
-        (**state)->parallax_depth         = depth;
-        (**state)->parallax_depth_authored = true;
+        (**state)->parallax.depth    = { depth[usize()], depth[usize(1)] };
+        (**state)->parallax.authored = true;
     }
     return owner.is_some() || state.is_some();
 }
@@ -337,7 +336,9 @@ auto UniformSceneState::NodeParallaxDepth(const SceneNode& node) const -> Option
     auto depth = m_node_parallax_depths.get(rstd::addressof(node));
     if (depth.is_some()) return Some(array<float, 2> { (**depth)[usize()], (**depth)[usize(1)] });
     auto state = m_nodes_by_address.get(rstd::addressof(node));
-    return state.is_some() ? Some((**state)->parallax_depth) : None();
+    return state.is_some() ? Some(array<float, 2> { (**state)->parallax.depth[0],
+                                                    (**state)->parallax.depth[1] })
+                           : None();
 }
 
 auto UniformSceneState::FindNodeState(const SceneNode* node) const -> const UniformNodeState* {
@@ -385,7 +386,7 @@ auto UniformSceneState::LogicalParallaxState(const UniformNodeState& state) cons
         }
     }
 
-    if (current->parallax_depth_authored) return current;
+    if (current->parallax.authored) return current;
 
     // Unauthored layers inherit from the nearest authored ancestor.
     auto remaining = m_nodes.len();
@@ -395,7 +396,7 @@ auto UniformSceneState::LogicalParallaxState(const UniformNodeState& state) cons
         --remaining;
         if (! parent->propagate_parallax_to_children) break;
         current = parent;
-        if (current->parallax_depth_authored) return current;
+        if (current->parallax.authored) return current;
     }
     return current;
 }
@@ -417,8 +418,8 @@ auto UniformSceneState::ComputeParallaxOffset(const UniformNodeState& state,
     const auto* source = LogicalParallaxState(state);
 
     array<float, 2> depth_values;
-    if (source->parallax_depth_authored) {
-        depth_values = source->parallax_depth;
+    if (source->parallax.authored) {
+        depth_values = { source->parallax.depth[0], source->parallax.depth[1] };
         if (wpscene::IsZeroParallaxDepth(depth_values)) return { 0.0f, 0.0f };
     } else if (m_orthographic_implicit_parallax) {
         depth_values = { wpscene::kImplicitOrthographicParallaxDepth[0],

--- a/src/Scene/Pkg/Parse/Uniform/UniformSource.cppm
+++ b/src/Scene/Pkg/Parse/Uniform/UniformSource.cppm
@@ -5,6 +5,7 @@ import rstd.cppstd;
 import wescene.json;
 import wescene.pkg.puppet;
 import wescene.scene;
+import wescene.pkg.scene_obj;
 import :global_uniform;
 import :particle_runtime;
 
@@ -132,8 +133,8 @@ inline auto TextureTexelOutput(std::size_t index) -> UniformOutputId {
 
 struct UniformCameraParallax {
     bool  enable { false };
-    float amount { 0.0f };
-    float delay { 0.0f };
+    float amount { 0.5f };
+    float delay { 0.1f };
     float mouse_influence { 0.0f };
 };
 
@@ -147,8 +148,7 @@ struct UniformCameraShake {
 struct UniformNodeConfigDraft {
     bool                    configured { false };
     i32                     object_id { 0 };
-    array<float, 2>         parallax_depth { 0.0f, 0.0f };
-    bool                    parallax_depth_authored { false };
+    wpscene::ParallaxDepthBinding parallax;
     bool                    propagate_parallax_to_children { true };
     bool                    ride_parent_parallax { false };
     bool                    use_camera_eye_position { false };
@@ -159,10 +159,9 @@ struct UniformNodeConfigDraft {
 
     auto Clone() const -> UniformNodeConfigDraft;
     auto CloneForRuntimeLayer(i32 owner) const -> UniformNodeConfigDraft;
-    void SetParallaxContract(array<float, 2> depth,
-                             i32             owner       = i32(),
-                             bool            authored    = false,
-                             bool            propagate_to_children = true);
+    void SetParallaxContract(wpscene::ParallaxDepthBinding binding,
+                             i32                         owner = i32(),
+                             bool                        propagate_to_children = true);
 };
 
 class UniformCameraResolver {
@@ -185,8 +184,7 @@ struct UniformNodeState {
     Arc<SceneNode>             node;
     Arc<UniformCameraResolver> camera_resolver;
     i32                        object_id { 0 };
-    array<float, 2>            parallax_depth { 0.0f, 0.0f };
-    bool                       parallax_depth_authored { false };
+    wpscene::ParallaxDepthBinding parallax;
     bool                       propagate_parallax_to_children { true };
     bool                       ride_parent_parallax { false };
     bool                       use_camera_eye_position { false };
@@ -211,7 +209,7 @@ public:
         : m_audio_demand(rstd::move(demand)) {}
 
     void SetNodeState(SceneNodeId, Arc<UniformNodeState>);
-    void RegisterNodeParallaxContract(const SceneNode&, i32, array<float, 2>, bool authored);
+    void RegisterNodeParallaxContract(const SceneNode&, i32, const wpscene::ParallaxDepthBinding&);
     bool SetEffectProjectionSize(SceneNodeId, array<float, 2>);
     bool SetObjectParallaxDepth(i32, array<float, 2>);
     bool SetNodeParallaxDepth(const SceneNode&, array<float, 2>);

--- a/src/Scene/Pkg/Parse/Uniform/UniformSource.cppm
+++ b/src/Scene/Pkg/Parse/Uniform/UniformSource.cppm
@@ -132,8 +132,8 @@ inline auto TextureTexelOutput(std::size_t index) -> UniformOutputId {
 
 struct UniformCameraParallax {
     bool  enable { false };
-    float amount { 0.5f };
-    float delay { 0.1f };
+    float amount { 0.0f };
+    float delay { 0.0f };
     float mouse_influence { 0.0f };
 };
 
@@ -147,7 +147,9 @@ struct UniformCameraShake {
 struct UniformNodeConfigDraft {
     bool                    configured { false };
     i32                     object_id { 0 };
-    array<float, 2>         parallax_depth { 1.0f, 1.0f };
+    array<float, 2>         parallax_depth { 0.0f, 0.0f };
+    bool                    parallax_depth_authored { false };
+    bool                    propagate_parallax_to_children { true };
     bool                    ride_parent_parallax { false };
     bool                    use_camera_eye_position { false };
     Option<array<float, 3>> eye_position_override;
@@ -157,7 +159,10 @@ struct UniformNodeConfigDraft {
 
     auto Clone() const -> UniformNodeConfigDraft;
     auto CloneForRuntimeLayer(i32 owner) const -> UniformNodeConfigDraft;
-    void SetParallaxContract(array<float, 2> depth, i32 owner = i32());
+    void SetParallaxContract(array<float, 2> depth,
+                             i32             owner       = i32(),
+                             bool            authored    = false,
+                             bool            propagate_to_children = true);
 };
 
 class UniformCameraResolver {
@@ -180,7 +185,9 @@ struct UniformNodeState {
     Arc<SceneNode>             node;
     Arc<UniformCameraResolver> camera_resolver;
     i32                        object_id { 0 };
-    array<float, 2>            parallax_depth { 1.0f, 1.0f };
+    array<float, 2>            parallax_depth { 0.0f, 0.0f };
+    bool                       parallax_depth_authored { false };
+    bool                       propagate_parallax_to_children { true };
     bool                       ride_parent_parallax { false };
     bool                       use_camera_eye_position { false };
     Option<array<float, 3>>    eye_position_override;
@@ -204,7 +211,7 @@ public:
         : m_audio_demand(rstd::move(demand)) {}
 
     void SetNodeState(SceneNodeId, Arc<UniformNodeState>);
-    void RegisterNodeParallaxContract(const SceneNode&, i32, array<float, 2>);
+    void RegisterNodeParallaxContract(const SceneNode&, i32, array<float, 2>, bool authored);
     bool SetEffectProjectionSize(SceneNodeId, array<float, 2>);
     bool SetObjectParallaxDepth(i32, array<float, 2>);
     bool SetNodeParallaxDepth(const SceneNode&, array<float, 2>);
@@ -222,6 +229,10 @@ public:
     array<float, 2>              Ortho() const noexcept { return m_ortho; }
 
     void SetOrtho(float width, float height) { m_ortho = { width, height }; }
+    void SetLayerParallaxPolicy(bool enabled, bool orthographic_implicit) {
+        m_layer_parallax_enabled          = enabled;
+        m_orthographic_implicit_parallax  = orthographic_implicit;
+    }
     void SetPointerInput(double, double);
     void SetAudioSpectrum(const scene_audio::Buffers&);
     void Advance(const SceneFrame&);
@@ -250,6 +261,8 @@ private:
     UniformFrameInputs       m_inputs;
     UniformCameraParallax    m_camera_parallax;
     UniformCameraShake       m_camera_shake;
+    bool                     m_layer_parallax_enabled { false };
+    bool                     m_orthographic_implicit_parallax { false };
     array<float, 2>          m_ortho { 1920.0f, 1080.0f };
     array<float, 2>          m_pointer_input { 0.5f, 0.5f };
     Arc<AudioResponseDemand> m_audio_demand;

--- a/src/Scene/Pkg/SceneObj/ImageObject.cpp
+++ b/src/Scene/Pkg/SceneObj/ImageObject.cpp
@@ -305,6 +305,11 @@ bool ImageObject::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion v) 
     owe::GetJsonValue(json, "id", id, false);
     owe::GetJsonValue(json, "colorBlendMode", colorBlendMode, false);
     ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
+    if (! parallaxDepthAuthored && composite_layer) {
+        // WE gives composite containers the regular layer depth when the field is omitted.
+        parallaxDepth         = { 1.0f, 1.0f };
+        parallaxDepthAuthored = true;
+    }
     if (! fullscreen) {
         owe::GetJsonValue(json, "origin", origin);
         owe::GetJsonValue(json, "angles", angles);

--- a/src/Scene/Pkg/SceneObj/ImageObject.cpp
+++ b/src/Scene/Pkg/SceneObj/ImageObject.cpp
@@ -304,11 +304,11 @@ bool ImageObject::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion v) 
     owe::GetJsonValue(json, "name", name, false);
     owe::GetJsonValue(json, "id", id, false);
     owe::GetJsonValue(json, "colorBlendMode", colorBlendMode, false);
-    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
-    if (! parallaxDepthAuthored && composite_layer) {
+    ReadParallaxDepth(json, parallax);
+    if (! parallax.authored && composite_layer) {
         // WE gives composite containers the regular layer depth when the field is omitted.
-        parallaxDepth         = { 1.0f, 1.0f };
-        parallaxDepthAuthored = true;
+        parallax.depth    = kImplicitOrthographicParallaxDepth;
+        parallax.authored = true;
     }
     if (! fullscreen) {
         owe::GetJsonValue(json, "origin", origin);
@@ -384,7 +384,7 @@ bool ShapeObject::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion v) 
     owe::GetJsonValue(json, "origin", origin);
     owe::GetJsonValue(json, "angles", angles);
     owe::GetJsonValue(json, "scale", scale);
-    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
+    ReadParallaxDepth(json, parallax);
 
     ReadImageEffects(json, vfs, v, effects);
 

--- a/src/Scene/Pkg/SceneObj/ImageObject.cppm
+++ b/src/Scene/Pkg/SceneObj/ImageObject.cppm
@@ -87,8 +87,7 @@ public:
     std::array<float, 3>     scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3>     angles { 0.0f, 0.0f, 0.0f };
     std::array<float, 2>     size { 2.0f, 2.0f };
-    std::array<float, 2>     parallaxDepth { kDefaultParallaxDepth };
-    bool                     parallaxDepthAuthored { false };
+    ParallaxDepthBinding     parallax;
     std::array<float, 3>     color { 1.0f, 1.0f, 1.0f };
     i32                      colorBlendMode { 0 };
     float                    alpha { 1.0f };
@@ -159,8 +158,7 @@ public:
     std::array<float, 3>     origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3>     scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3>     angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2>     parallaxDepth { kDefaultParallaxDepth };
-    bool                     parallaxDepthAuthored { false };
+    ParallaxDepthBinding     parallax;
     bool                     visible { true };
     std::vector<ImageEffect> effects;
 

--- a/src/Scene/Pkg/SceneObj/LightObject.cpp
+++ b/src/Scene/Pkg/SceneObj/LightObject.cpp
@@ -21,7 +21,7 @@ bool LightObject::FromJson(const owe::Json& json, fs::VFS&, SceneVersion /*v*/) 
     visible_user_key = visible_user.name;
     owe::GetJsonValue(json, "name", name, false);
     owe::GetJsonValue(json, "id", id, false);
-    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
+    ReadParallaxDepth(json, parallax);
     owe::GetJsonValue(json, "shape", shape, false);
     owe::GetJsonValue(json, "locktransforms", locktransforms, false);
     owe::GetJsonValue(json, "muteineditor", muteineditor, false);

--- a/src/Scene/Pkg/SceneObj/LightObject.cppm
+++ b/src/Scene/Pkg/SceneObj/LightObject.cppm
@@ -25,8 +25,7 @@ public:
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
-    bool                 parallaxDepthAuthored { false };
+    ParallaxDepthBinding parallax;
     std::array<float, 3> color { 1.0f, 1.0f, 1.0f };
     std::string          light; // "point" / "spot" / "directional" / ...
     std::string          shape; // PKGV0021+

--- a/src/Scene/Pkg/SceneObj/MiscObject.cppm
+++ b/src/Scene/Pkg/SceneObj/MiscObject.cppm
@@ -31,8 +31,7 @@ struct TextObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
-    bool                 parallaxDepthAuthored { false };
+    ParallaxDepthBinding parallax;
     bool                 visible { true };
 
     bool             locktransforms { false };
@@ -90,7 +89,7 @@ struct TextObject {
         owe::GetJsonValue(json, "origin", origin, false);
         owe::GetJsonValue(json, "scale", scale, false);
         owe::GetJsonValue(json, "angles", angles, false);
-        ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
+        ReadParallaxDepth(json, parallax);
         ReadVisibleProperty(json, visible, visible_user);
         visible_user_key = visible_user.name;
         owe::GetJsonValue(json, "locktransforms", locktransforms, false);
@@ -153,8 +152,7 @@ struct ModelObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
-    bool                 parallaxDepthAuthored { false };
+    ParallaxDepthBinding parallax;
     bool                 visible { true };
 
     bool             locktransforms { false };
@@ -185,7 +183,7 @@ struct ModelObject {
         owe::GetJsonValue(json, "origin", origin, false);
         owe::GetJsonValue(json, "scale", scale, false);
         owe::GetJsonValue(json, "angles", angles, false);
-        ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
+        ReadParallaxDepth(json, parallax);
         ReadVisibleProperty(json, visible, visible_user);
         visible_user_key = visible_user.name;
         owe::GetJsonValue(json, "locktransforms", locktransforms, false);
@@ -216,8 +214,7 @@ struct CameraObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallaxDepth { kDefaultParallaxDepth };
-    bool                 parallaxDepthAuthored { false };
+    ParallaxDepthBinding parallax;
     bool                 visible { true };
 
     bool             locktransforms { false };
@@ -248,7 +245,7 @@ struct CameraObject {
         owe::GetJsonValue(json, "origin", origin, false);
         owe::GetJsonValue(json, "scale", scale, false);
         owe::GetJsonValue(json, "angles", angles, false);
-        ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
+        ReadParallaxDepth(json, parallax);
         ReadVisibleProperty(json, visible, visible_user);
         visible_user_key = visible_user.name;
         owe::GetJsonValue(json, "locktransforms", locktransforms, false);

--- a/src/Scene/Pkg/SceneObj/Object.cpp
+++ b/src/Scene/Pkg/SceneObj/Object.cpp
@@ -18,7 +18,7 @@ bool ContainerObject::FromJson(const owe::Json& json) {
     owe::GetJsonValue(json, "origin", origin, false);
     owe::GetJsonValue(json, "scale", scale, false);
     owe::GetJsonValue(json, "angles", angles, false);
-    ReadParallaxDepth(json, parallax_depth, parallax_depth_authored);
+    ReadParallaxDepth(json, parallax);
     ReadVisibleProperty(json, visible, visible_user);
     owe::GetJsonValue(json, "solid", solid, false);
     owe::GetJsonValue(json, "disablepropagation", disable_propagation, false);
@@ -113,6 +113,19 @@ Vec<SceneObject> DecodeSceneObjects(ref<SceneDocument> document, mut_ref<fs::VFS
         }
     }
     return objects;
+}
+
+bool SceneObjectParallaxAuthored(const SceneObject& object) {
+    if (object.is_Container()) return object.as_Container().value.parallax.authored;
+    if (object.is_Image()) return object.as_Image().value.parallax.authored;
+    if (object.is_Shape()) return object.as_Shape().value.parallax.authored;
+    if (object.is_Particle()) return object.as_Particle().value.parallax.authored;
+    if (object.is_Sound()) return false;
+    if (object.is_Light()) return object.as_Light().value.parallax.authored;
+    if (object.is_Text()) return object.as_Text().value.parallax.authored;
+    if (object.is_Model()) return object.as_Model().value.parallax.authored;
+    if (object.is_Camera()) return object.as_Camera().value.parallax.authored;
+    return false;
 }
 
 } // namespace owe::wpscene

--- a/src/Scene/Pkg/SceneObj/Object.cppm
+++ b/src/Scene/Pkg/SceneObj/Object.cppm
@@ -25,8 +25,7 @@ struct ContainerObject {
     std::array<float, 3> origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3> scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3> angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2> parallax_depth { kDefaultParallaxDepth };
-    bool                 parallax_depth_authored { false };
+    ParallaxDepthBinding parallax;
     bool                 visible { true };
     bool                 solid { false };
     bool                 disable_propagation { false };
@@ -47,5 +46,7 @@ class SceneObject {
 };
 
 Vec<SceneObject> DecodeSceneObjects(ref<SceneDocument>, mut_ref<fs::VFS>);
+
+bool SceneObjectParallaxAuthored(const SceneObject& object);
 
 } // namespace owe::wpscene

--- a/src/Scene/Pkg/SceneObj/ParticleObject.cpp
+++ b/src/Scene/Pkg/SceneObj/ParticleObject.cpp
@@ -326,7 +326,7 @@ ParticleObject ParticleObject::Clone() const {
     out.origin           = origin;
     out.scale            = scale;
     out.angles           = angles;
-    out.parallaxDepth    = parallaxDepth;
+    out.parallax           = parallax;
     out.visible          = visible;
     out.particle         = particle;
     out.particleObj      = particleObj.Clone();
@@ -343,7 +343,6 @@ ParticleObject ParticleObject::Clone() const {
     out.controlpoint     = controlpoint;
     out.visible_user_key = visible_user_key;
 
-    out.parallaxDepthAuthored = parallaxDepthAuthored;
     return out;
 }
 
@@ -357,7 +356,7 @@ bool ParticleObject::FromJson(const owe::Json& json, fs::VFS& vfs, SceneVersion 
     owe::GetJsonValue(json, "origin", origin);
     owe::GetJsonValue(json, "angles", angles);
     owe::GetJsonValue(json, "scale", scale);
-    ReadParallaxDepth(json, parallaxDepth, parallaxDepthAuthored);
+    ReadParallaxDepth(json, parallax);
 
     if (auto value = json.get("instanceoverride"_str); value.is_some() && ! (*value)->is_null()) {
         instanceoverride.FromJosn(**value);

--- a/src/Scene/Pkg/SceneObj/ParticleObject.cppm
+++ b/src/Scene/Pkg/SceneObj/ParticleObject.cppm
@@ -196,8 +196,7 @@ public:
     std::array<float, 3>     origin { 0.0f, 0.0f, 0.0f };
     std::array<float, 3>     scale { 1.0f, 1.0f, 1.0f };
     std::array<float, 3>     angles { 0.0f, 0.0f, 0.0f };
-    std::array<float, 2>     parallaxDepth { kDefaultParallaxDepth };
-    bool                     parallaxDepthAuthored { false };
+    ParallaxDepthBinding     parallax;
     bool                     visible { true };
     std::string              particle;
     Particle                 particleObj;

--- a/src/Scene/Pkg/SceneObj/SceneDocument.cppm
+++ b/src/Scene/Pkg/SceneObj/SceneDocument.cppm
@@ -16,20 +16,27 @@ export namespace owe
 namespace wpscene
 {
 
-// Omitted parallaxDepth is stored as 0.0. Orthographic scenes resolve omitted layers to
-// kImplicitOrthographicParallaxDepth at runtime when layer parallax is enabled.
+// parallaxDepth rules (resolved in UniformSceneState::ComputeParallaxOffset):
+// - omitted: stored as kDefaultParallaxDepth; orthographic scenes use kImplicitOrthographicParallaxDepth
+// - explicit value: used as authored depth (including {0,0} = frozen layer)
+// - perspective scenes without any authored depth: layer parallax stays disabled
 inline constexpr std::array<float, 2> kDefaultParallaxDepth { 0.0f, 0.0f };
 inline constexpr std::array<float, 2> kImplicitOrthographicParallaxDepth { 1.0f, 1.0f };
+
+struct ParallaxDepthBinding {
+    std::array<float, 2> depth { kDefaultParallaxDepth };
+    bool                 authored { false };
+};
 
 inline bool JsonHasParallaxDepth(const owe::Json& json) {
     auto member = json.get("parallaxDepth"_str);
     return member.is_some() && ! (*member)->is_null();
 }
 
-inline void ReadParallaxDepth(const owe::Json& json, std::array<float, 2>& depth, bool& authored) {
-    authored = JsonHasParallaxDepth(json);
-    depth    = kDefaultParallaxDepth;
-    if (authored) (void)owe::GetJsonValue(json, "parallaxDepth", depth, false);
+inline void ReadParallaxDepth(const owe::Json& json, ParallaxDepthBinding& binding) {
+    binding.authored = JsonHasParallaxDepth(json);
+    binding.depth    = kDefaultParallaxDepth;
+    if (binding.authored) (void)owe::GetJsonValue(json, "parallaxDepth", binding.depth, false);
 }
 
 inline bool IsZeroParallaxDepth(const std::array<float, 2>& depth) {
@@ -101,8 +108,8 @@ public:
     bool                 camerafade { false };
     bool                 camerapreview { false };
     bool                 cameraparallax { false };
-    float                cameraparallaxamount { 0.0f };
-    float                cameraparallaxdelay { 0.0f };
+    float                cameraparallaxamount { 0.5f };
+    float                cameraparallaxdelay { 0.1f };
     float                cameraparallaxmouseinfluence { 0.0f };
     bool                 isOrtho { false };
     Orthogonalprojection orthogonalprojection { i32(1920), i32(1080) };

--- a/src/Scene/Pkg/SceneObj/SceneDocument.cppm
+++ b/src/Scene/Pkg/SceneObj/SceneDocument.cppm
@@ -16,8 +16,10 @@ export namespace owe
 namespace wpscene
 {
 
-// Omitted parallaxDepth uses 1.0. Child layers follow the unparented ancestor.
-inline constexpr std::array<float, 2> kDefaultParallaxDepth { 1.0f, 1.0f };
+// Omitted parallaxDepth is stored as 0.0. Orthographic scenes resolve omitted layers to
+// kImplicitOrthographicParallaxDepth at runtime when layer parallax is enabled.
+inline constexpr std::array<float, 2> kDefaultParallaxDepth { 0.0f, 0.0f };
+inline constexpr std::array<float, 2> kImplicitOrthographicParallaxDepth { 1.0f, 1.0f };
 
 inline bool JsonHasParallaxDepth(const owe::Json& json) {
     auto member = json.get("parallaxDepth"_str);
@@ -32,6 +34,10 @@ inline void ReadParallaxDepth(const owe::Json& json, std::array<float, 2>& depth
 
 inline bool IsZeroParallaxDepth(const std::array<float, 2>& depth) {
     return depth[0] * depth[0] + depth[1] * depth[1] <= 1e-12f;
+}
+
+inline bool IsZeroParallaxDepth(const rstd::array<float, 2>& depth) {
+    return depth[usize()] * depth[usize()] + depth[usize(1)] * depth[usize(1)] <= 1e-12f;
 }
 
 // pkg container version (the "PKGV00xx" stamp at the head of scene.pkg).
@@ -95,8 +101,8 @@ public:
     bool                 camerafade { false };
     bool                 camerapreview { false };
     bool                 cameraparallax { false };
-    float                cameraparallaxamount { 0.5f };
-    float                cameraparallaxdelay { 0.1f };
+    float                cameraparallaxamount { 0.0f };
+    float                cameraparallaxdelay { 0.0f };
     float                cameraparallaxmouseinfluence { 0.0f };
     bool                 isOrtho { false };
     Orthogonalprojection orthogonalprojection { i32(1920), i32(1080) };

--- a/tests/tests/scene-runtime/scene_runtime_tests.cpp
+++ b/tests/tests/scene-runtime/scene_runtime_tests.cpp
@@ -852,6 +852,7 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
     effect->SetParentAnchor(child.as_ptr());
 
     auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->SetLayerParallaxPolicy(true, true);
     state->CameraParallax() = { true, 0.03f, 0.0f, 0.36f };
     state->SetOrtho(3840.0f, 2160.0f);
     state->SetPointerInput(0.0, 1.0);
@@ -861,14 +862,17 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
     camera_resolver->Add(String::make("default"_str), camera.clone());
 
     auto parent_state = Arc<owe::UniformNodeState>::make(parent.clone(), camera_resolver.clone());
-    parent_state->object_id      = i32(1);
-    parent_state->parallax_depth = { -1.56f, -0.79f };
+    parent_state->object_id               = i32(1);
+    parent_state->parallax_depth          = { -1.56f, -0.79f };
+    parent_state->parallax_depth_authored = true;
     auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
-    child_state->object_id      = i32(2);
-    child_state->parallax_depth = { 1.0f, 1.0f };
+    child_state->object_id               = i32(2);
+    child_state->parallax_depth          = { 1.0f, 1.0f };
+    child_state->parallax_depth_authored = false;
     auto effect_state = Arc<owe::UniformNodeState>::make(effect.clone(), camera_resolver.clone());
     effect_state->object_id              = i32(2);
     effect_state->parallax_depth         = { 1.0f, 1.0f };
+    effect_state->parallax_depth_authored = false;
     effect_state->effect_projection_node = Some(child.clone());
     state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) },
                         parent_state.clone());
@@ -933,4 +937,377 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
     mvp = capture_mvp();
     EXPECT_NEAR(mvp[rstd::usize(12)], 0.0f, 1e-5f);
     EXPECT_NEAR(mvp[rstd::usize(13)], 0.0f, 1e-5f);
+}
+
+TEST(UniformSourceParallax, OrthographicOmittedDepthUsesImplicitParallax) {
+    owe::Scene scene;
+    scene.SetOrtho({ i32(1920), i32(1080) });
+
+    auto camera_node = Arc<owe::SceneNode>::make(Eigen::Vector3f { 960.0f, 540.0f, 0.0f },
+                                                 Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                                 Eigen::Vector3f::Zero());
+    auto camera =
+        Arc<owe::SceneCamera>::make(owe::SceneCamera::MakeOrthographic(1920, 1080, -1.0, 1.0));
+    camera->AttatchNode(camera_node.as_ptr());
+    scene.RegisterCamera(String::make("default"_str), camera.clone());
+    ASSERT_TRUE(scene.SetActiveCamera("default"_str));
+
+    auto layer = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1200.0f, 700.0f, 0.0f },
+                                           Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                           Eigen::Vector3f::Zero());
+    auto mesh = std::make_shared<owe::SceneMesh>();
+    mesh->AddMaterial(owe::SceneMaterial {});
+    owe::SceneMesh::Submesh submesh;
+    submesh.material_slot = u32();
+    mesh->Submeshes().push_back(std::move(submesh));
+    layer->AddMesh(mesh);
+    scene.RootMut()->AppendChild(layer.clone());
+    scene.RebuildResourceIndex();
+
+    auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->SetLayerParallaxPolicy(true, true);
+    state->CameraParallax() = { true, 0.5f, 0.0f, 0.36f };
+    state->SetOrtho(1920.0f, 1080.0f);
+    state->SetPointerInput(0.0, 1.0);
+    state->Advance(owe::SceneFrame {});
+
+    auto camera_resolver = Arc<owe::UniformCameraResolver>::make(camera.clone());
+    camera_resolver->Add(String::make("default"_str), camera.clone());
+
+    auto layer_state = Arc<owe::UniformNodeState>::make(layer.clone(), camera_resolver.clone());
+    layer_state->object_id               = i32(1);
+    layer_state->parallax_depth          = { 0.0f, 0.0f };
+    layer_state->parallax_depth_authored = false;
+    state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) }, layer_state.clone());
+
+    owe::TransformUniformSource source(state.clone(), layer_state.clone());
+    state->CameraParallax().enable = false;
+    auto mvp_without_parallax = scene_test::Capture(
+        scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+    state->CameraParallax().enable = true;
+    auto mvp_with_parallax = scene_test::Capture(
+        scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+    ASSERT_GT(mvp_without_parallax.size().to_primitive(), 13u);
+    ASSERT_GT(mvp_with_parallax.size().to_primitive(), 13u);
+    EXPECT_TRUE(std::abs(mvp_without_parallax[rstd::usize(12)] - mvp_with_parallax[rstd::usize(12)]) >
+                    1e-5f ||
+                std::abs(mvp_without_parallax[rstd::usize(13)] - mvp_with_parallax[rstd::usize(13)]) >
+                    1e-5f);
+}
+
+TEST(UniformSourceParallax, UnregisteredContainerRootDoesNotPoisonChildren) {
+    owe::Scene scene;
+    scene.SetOrtho({ i32(3840), i32(2160) });
+
+    auto camera_node = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1920.0f, 1080.0f, 0.0f },
+                                                 Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                                 Eigen::Vector3f::Zero());
+    auto camera =
+        Arc<owe::SceneCamera>::make(owe::SceneCamera::MakeOrthographic(3840, 2160, -1.0, 1.0));
+    camera->AttatchNode(camera_node.as_ptr());
+    scene.RegisterCamera(String::make("default"_str), camera.clone());
+    ASSERT_TRUE(scene.SetActiveCamera("default"_str));
+
+    auto container = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1982.0f, 1053.0f, 0.0f },
+                                              Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                              Eigen::Vector3f::Zero());
+    auto child = Arc<owe::SceneNode>::make(Eigen::Vector3f { -76.0f, -3.0f, 0.0f },
+                                          Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                          Eigen::Vector3f::Zero());
+    auto mesh  = std::make_shared<owe::SceneMesh>();
+    mesh->AddMaterial(owe::SceneMaterial {});
+    owe::SceneMesh::Submesh submesh;
+    submesh.material_slot = u32();
+    mesh->Submeshes().push_back(std::move(submesh));
+    child->AddMesh(mesh);
+    container->AppendChild(child.clone());
+    scene.RootMut()->AppendChild(container.clone());
+    scene.RebuildResourceIndex();
+
+    auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->SetLayerParallaxPolicy(true, true);
+    state->CameraParallax() = { true, 0.03f, 0.0f, 0.36f };
+    state->SetOrtho(3840.0f, 2160.0f);
+    state->SetPointerInput(0.0, 1.0);
+    state->Advance(owe::SceneFrame {});
+
+    auto camera_resolver = Arc<owe::UniformCameraResolver>::make(camera.clone());
+    camera_resolver->Add(String::make("default"_str), camera.clone());
+
+    auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
+    child_state->object_id               = i32(2);
+    child_state->parallax_depth          = { -1.12f, -1.36f };
+    child_state->parallax_depth_authored = true;
+    state->SetNodeState({ .index = rstd::u32(2), .generation = rstd::u32(1) }, child_state.clone());
+
+    owe::TransformUniformSource source(state.clone(), child_state.clone());
+    auto mvp = scene_test::Capture(
+        scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+
+    const Eigen::Vector2f camera_pos { 1920.0f, 1080.0f };
+    const Eigen::Vector2f mouse_vec { 691.2f, 388.8f };
+    const Eigen::Vector2f depth { -1.12f, -1.36f };
+    const Eigen::Vector2f base { 1906.0f, 1050.0f };
+    const Eigen::Vector2f offset =
+        (base - camera_pos + mouse_vec).cwiseProduct(depth) * 0.03f;
+    const Eigen::Vector2f final_pos = base + offset;
+    const Eigen::Vector2f expected {
+        (final_pos.x() - 1920.0f) / 1920.0f,
+        (final_pos.y() - 1080.0f) / 1080.0f,
+    };
+
+    ASSERT_GT(mvp.size().to_primitive(), 13u);
+    EXPECT_NEAR(mvp[rstd::usize(12)], expected.x(), 1e-5f);
+    EXPECT_NEAR(mvp[rstd::usize(13)], expected.y(), 1e-5f);
+}
+
+TEST(UniformSourceParallax, DisablePropagationBlocksInheritance) {
+    owe::Scene scene;
+    scene.SetOrtho({ i32(3840), i32(2160) });
+
+    auto camera_node = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1920.0f, 1080.0f, 0.0f },
+                                                 Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                                 Eigen::Vector3f::Zero());
+    auto camera =
+        Arc<owe::SceneCamera>::make(owe::SceneCamera::MakeOrthographic(3840, 2160, -1.0, 1.0));
+    camera->AttatchNode(camera_node.as_ptr());
+    scene.RegisterCamera(String::make("default"_str), camera.clone());
+    ASSERT_TRUE(scene.SetActiveCamera("default"_str));
+
+    auto parent = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1982.0f, 1053.0f, 0.0f },
+                                            Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                            Eigen::Vector3f::Zero());
+    auto child  = Arc<owe::SceneNode>::make(Eigen::Vector3f { -76.0f, -3.0f, 0.0f },
+                                            Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                            Eigen::Vector3f::Zero());
+    auto mesh   = std::make_shared<owe::SceneMesh>();
+    mesh->AddMaterial(owe::SceneMaterial {});
+    owe::SceneMesh::Submesh submesh;
+    submesh.material_slot = u32();
+    mesh->Submeshes().push_back(std::move(submesh));
+    child->AddMesh(mesh);
+    parent->AppendChild(child.clone());
+    scene.RootMut()->AppendChild(parent.clone());
+    scene.RebuildResourceIndex();
+
+    auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->SetLayerParallaxPolicy(true, true);
+    state->CameraParallax() = { true, 0.03f, 0.0f, 0.36f };
+    state->SetOrtho(3840.0f, 2160.0f);
+    state->SetPointerInput(0.0, 1.0);
+    state->Advance(owe::SceneFrame {});
+
+    auto camera_resolver = Arc<owe::UniformCameraResolver>::make(camera.clone());
+    camera_resolver->Add(String::make("default"_str), camera.clone());
+
+    auto parent_state = Arc<owe::UniformNodeState>::make(parent.clone(), camera_resolver.clone());
+    parent_state->object_id                      = i32(1);
+    parent_state->parallax_depth                 = { -1.56f, -0.79f };
+    parent_state->parallax_depth_authored        = true;
+    parent_state->propagate_parallax_to_children = false;
+    auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
+    child_state->object_id               = i32(2);
+    child_state->parallax_depth          = { 0.0f, 0.0f };
+    child_state->parallax_depth_authored = false;
+    state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) },
+                        parent_state.clone());
+    state->SetNodeState({ .index = rstd::u32(2), .generation = rstd::u32(1) }, child_state.clone());
+
+    owe::TransformUniformSource source(state.clone(), child_state.clone());
+    auto capture_mvp = [&]() {
+        return scene_test::Capture(
+            scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+    };
+
+    parent_state->propagate_parallax_to_children = true;
+    auto mvp_inherited = capture_mvp();
+
+    parent_state->propagate_parallax_to_children = false;
+    auto mvp_blocked = capture_mvp();
+
+    ASSERT_GT(mvp_inherited.size().to_primitive(), 13u);
+    ASSERT_GT(mvp_blocked.size().to_primitive(), 13u);
+    EXPECT_TRUE(std::abs(mvp_inherited[rstd::usize(12)] - mvp_blocked[rstd::usize(12)]) > 1e-5f ||
+                std::abs(mvp_inherited[rstd::usize(13)] - mvp_blocked[rstd::usize(13)]) > 1e-5f);
+}
+
+TEST(UniformSourceParallax, EffectModelReceivesParallaxShift) {
+    owe::Scene scene;
+    scene.SetOrtho({ i32(3840), i32(2160) });
+
+    auto camera_node = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1920.0f, 1080.0f, 0.0f },
+                                                 Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                                 Eigen::Vector3f::Zero());
+    auto camera =
+        Arc<owe::SceneCamera>::make(owe::SceneCamera::MakeOrthographic(3840, 2160, -1.0, 1.0));
+    camera->AttatchNode(camera_node.as_ptr());
+    scene.RegisterCamera(String::make("default"_str), camera.clone());
+    ASSERT_TRUE(scene.SetActiveCamera("default"_str));
+
+    auto parent = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1982.0f, 1053.0f, 0.0f },
+                                            Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                            Eigen::Vector3f::Zero());
+    auto child  = Arc<owe::SceneNode>::make(Eigen::Vector3f { -76.0f, -3.0f, 0.0f },
+                                            Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
+                                            Eigen::Vector3f::Zero());
+    auto effect = Arc<owe::SceneNode>::make();
+    auto mesh   = std::make_shared<owe::SceneMesh>();
+    mesh->AddMaterial(owe::SceneMaterial {});
+    owe::SceneMesh::Submesh submesh;
+    submesh.material_slot = u32();
+    mesh->Submeshes().push_back(std::move(submesh));
+    child->AddMesh(mesh);
+    parent->AppendChild(child.clone());
+    scene.RootMut()->AppendChild(parent.clone());
+    scene.RebuildResourceIndex();
+    effect->SetParentAnchor(child.as_ptr());
+
+    auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->SetLayerParallaxPolicy(true, true);
+    state->CameraParallax() = { true, 0.03f, 0.0f, 0.36f };
+    state->SetOrtho(3840.0f, 2160.0f);
+    state->SetPointerInput(0.0, 1.0);
+    state->Advance(owe::SceneFrame {});
+
+    auto camera_resolver = Arc<owe::UniformCameraResolver>::make(camera.clone());
+    camera_resolver->Add(String::make("default"_str), camera.clone());
+
+    auto parent_state = Arc<owe::UniformNodeState>::make(parent.clone(), camera_resolver.clone());
+    parent_state->object_id               = i32(1);
+    parent_state->parallax_depth          = { -1.56f, -0.79f };
+    parent_state->parallax_depth_authored = true;
+    auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
+    child_state->object_id               = i32(2);
+    child_state->parallax_depth          = { 1.0f, 1.0f };
+    child_state->parallax_depth_authored = false;
+    auto effect_state = Arc<owe::UniformNodeState>::make(effect.clone(), camera_resolver.clone());
+    effect_state->object_id               = i32(2);
+    effect_state->parallax_depth          = { 1.0f, 1.0f };
+    effect_state->parallax_depth_authored = false;
+    effect_state->effect_projection_node  = Some(child.clone());
+    effect_state->effect_projection_size  = { 3840.0f, 2160.0f };
+    state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) },
+                        parent_state.clone());
+    state->SetNodeState({ .index = rstd::u32(2), .generation = rstd::u32(1) }, child_state.clone());
+    state->SetNodeState({ .index = rstd::u32(3), .generation = rstd::u32(1) },
+                        effect_state.clone());
+
+    owe::TransformUniformSource source(state.clone(), effect_state.clone());
+    auto effect_enabled =
+        scene_test::Capture(scene.Runtime().Frame(), source, owe::TransformUniformOutput::EffectModel);
+    state->CameraParallax().enable = false;
+    auto effect_disabled =
+        scene_test::Capture(scene.Runtime().Frame(), source, owe::TransformUniformOutput::EffectModel);
+    ASSERT_GT(effect_enabled.size().to_primitive(), 13u);
+    ASSERT_GT(effect_disabled.size().to_primitive(), 13u);
+    EXPECT_TRUE(std::abs(effect_enabled[rstd::usize(12)] - effect_disabled[rstd::usize(12)]) > 1e-4f ||
+                std::abs(effect_enabled[rstd::usize(13)] - effect_disabled[rstd::usize(13)]) > 1e-4f);
+}
+
+TEST(UniformSourceParallax, PerspectiveWithoutAuthoredParallaxDepthSkipsShift) {
+    owe::Scene scene;
+    scene.SetOrtho({ i32(1920), i32(1080) });
+
+    auto camera =
+        Arc<owe::SceneCamera>::make(owe::SceneCamera::MakePerspective(16.0 / 9.0, 0.1, 10000.0, 60.0));
+    camera->SetLookAt(Eigen::Vector3d { -1.69, 0.62, 9.29 },
+                      Eigen::Vector3d { -1.58, 0.60, 8.30 },
+                      Eigen::Vector3d::UnitY());
+    scene.RegisterCamera(String::make("default"_str), camera.clone());
+    ASSERT_TRUE(scene.SetActiveCamera("default"_str));
+
+    auto layer = Arc<owe::SceneNode>::make(Eigen::Vector3f { 0.0f, 0.0f, 3.0f },
+                                           Eigen::Vector3f { 0.0025f, 0.0025f, 5.0f },
+                                           Eigen::Vector3f::Zero());
+    auto mesh = std::make_shared<owe::SceneMesh>();
+    mesh->AddMaterial(owe::SceneMaterial {});
+    owe::SceneMesh::Submesh submesh;
+    submesh.material_slot = u32();
+    mesh->Submeshes().push_back(std::move(submesh));
+    layer->AddMesh(mesh);
+    scene.RootMut()->AppendChild(layer.clone());
+    scene.RebuildResourceIndex();
+
+    auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->SetLayerParallaxPolicy(false, false);
+    state->CameraParallax() = { true, 2.0f, 0.0f, 1.0f };
+    state->SetOrtho(1920.0f, 1080.0f);
+    state->SetPointerInput(0.0, 1.0);
+    state->Advance(owe::SceneFrame {});
+
+    auto camera_resolver = Arc<owe::UniformCameraResolver>::make(camera.clone());
+    camera_resolver->Add(String::make("default"_str), camera.clone());
+
+    auto layer_state = Arc<owe::UniformNodeState>::make(layer.clone(), camera_resolver.clone());
+    layer_state->object_id               = i32(31);
+    layer_state->parallax_depth          = { 0.0f, 0.0f };
+    layer_state->parallax_depth_authored = false;
+    state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) }, layer_state.clone());
+
+    owe::TransformUniformSource source(state.clone(), layer_state.clone());
+    state->CameraParallax().enable = false;
+    auto mvp_without_parallax = scene_test::Capture(
+        scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+    state->CameraParallax().enable = true;
+    auto mvp_with_parallax = scene_test::Capture(
+        scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+    ASSERT_GT(mvp_without_parallax.size().to_primitive(), 13u);
+    ASSERT_GT(mvp_with_parallax.size().to_primitive(), 13u);
+    EXPECT_NEAR(mvp_without_parallax[rstd::usize(12)], mvp_with_parallax[rstd::usize(12)], 1e-5f);
+    EXPECT_NEAR(mvp_without_parallax[rstd::usize(13)], mvp_with_parallax[rstd::usize(13)], 1e-5f);
+}
+
+TEST(UniformSourceParallax, PerspectiveWithAuthoredParallaxDepthAppliesShift) {
+    owe::Scene scene;
+    scene.SetOrtho({ i32(1920), i32(1080) });
+
+    auto camera =
+        Arc<owe::SceneCamera>::make(owe::SceneCamera::MakePerspective(16.0 / 9.0, 0.1, 10000.0, 60.0));
+    camera->SetLookAt(Eigen::Vector3d { 0.0, 0.0, 5.0 },
+                      Eigen::Vector3d::Zero(),
+                      Eigen::Vector3d::UnitY());
+    scene.RegisterCamera(String::make("default"_str), camera.clone());
+    ASSERT_TRUE(scene.SetActiveCamera("default"_str));
+
+    auto layer = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1.0f, 2.0f, -3.0f },
+                                           Eigen::Vector3f::Ones(),
+                                           Eigen::Vector3f::Zero());
+    auto mesh = std::make_shared<owe::SceneMesh>();
+    mesh->AddMaterial(owe::SceneMaterial {});
+    owe::SceneMesh::Submesh submesh;
+    submesh.material_slot = u32();
+    mesh->Submeshes().push_back(std::move(submesh));
+    layer->AddMesh(mesh);
+    scene.RootMut()->AppendChild(layer.clone());
+    scene.RebuildResourceIndex();
+
+    auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
+    state->SetLayerParallaxPolicy(true, false);
+    state->CameraParallax() = { true, 0.5f, 0.0f, 1.0f };
+    state->SetOrtho(1920.0f, 1080.0f);
+    state->SetPointerInput(0.0, 1.0);
+    state->Advance(owe::SceneFrame {});
+
+    auto camera_resolver = Arc<owe::UniformCameraResolver>::make(camera.clone());
+    camera_resolver->Add(String::make("default"_str), camera.clone());
+
+    auto layer_state = Arc<owe::UniformNodeState>::make(layer.clone(), camera_resolver.clone());
+    layer_state->object_id               = i32(1);
+    layer_state->parallax_depth          = { 1.0f, 1.0f };
+    layer_state->parallax_depth_authored = true;
+    state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) }, layer_state.clone());
+
+    owe::TransformUniformSource source(state.clone(), layer_state.clone());
+    state->CameraParallax().enable = false;
+    auto mvp_without_parallax = scene_test::Capture(
+        scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+    state->CameraParallax().enable = true;
+    auto mvp_with_parallax = scene_test::Capture(
+        scene.Runtime().Frame(), source, owe::TransformUniformOutput::ModelViewProjection);
+    ASSERT_GT(mvp_without_parallax.size().to_primitive(), 13u);
+    ASSERT_GT(mvp_with_parallax.size().to_primitive(), 13u);
+    EXPECT_TRUE(std::abs(mvp_without_parallax[rstd::usize(12)] - mvp_with_parallax[rstd::usize(12)]) >
+                    1e-5f ||
+                std::abs(mvp_without_parallax[rstd::usize(13)] - mvp_with_parallax[rstd::usize(13)]) >
+                    1e-5f);
 }

--- a/tests/tests/scene-runtime/scene_runtime_tests.cpp
+++ b/tests/tests/scene-runtime/scene_runtime_tests.cpp
@@ -863,16 +863,16 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
 
     auto parent_state = Arc<owe::UniformNodeState>::make(parent.clone(), camera_resolver.clone());
     parent_state->object_id               = i32(1);
-    parent_state->parallax_depth          = { -1.56f, -0.79f };
-    parent_state->parallax_depth_authored = true;
+    parent_state->parallax.depth    = { -1.56f, -0.79f };
+    parent_state->parallax.authored = true;
     auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
     child_state->object_id               = i32(2);
-    child_state->parallax_depth          = { 1.0f, 1.0f };
-    child_state->parallax_depth_authored = false;
+    child_state->parallax.depth    = { 1.0f, 1.0f };
+    child_state->parallax.authored = false;
     auto effect_state = Arc<owe::UniformNodeState>::make(effect.clone(), camera_resolver.clone());
     effect_state->object_id              = i32(2);
-    effect_state->parallax_depth         = { 1.0f, 1.0f };
-    effect_state->parallax_depth_authored = false;
+    effect_state->parallax.depth    = { 1.0f, 1.0f };
+    effect_state->parallax.authored = false;
     effect_state->effect_projection_node = Some(child.clone());
     state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) },
                         parent_state.clone());
@@ -902,25 +902,25 @@ TEST(UniformSourceParallax, ParentPropagationSelectsAncestorConfiguration) {
     EXPECT_NEAR(mvp[rstd::usize(12)], expected_inherited.x(), 1e-5f);
     EXPECT_NEAR(mvp[rstd::usize(13)], expected_inherited.y(), 1e-5f);
 
-    child_state->parallax_depth = { 0.0f, 0.0f };
+    child_state->parallax.depth = { 0.0f, 0.0f };
     mvp                         = capture_mvp();
     EXPECT_NEAR(mvp[rstd::usize(12)], expected_inherited.x(), 1e-5f);
     EXPECT_NEAR(mvp[rstd::usize(13)], expected_inherited.y(), 1e-5f);
 
-    child_state->parallax_depth = { 0.5f, 0.5f };
+    child_state->parallax.depth = { 0.5f, 0.5f };
     mvp                         = capture_mvp();
     EXPECT_NEAR(mvp[rstd::usize(12)], expected_inherited.x(), 1e-5f);
     EXPECT_NEAR(mvp[rstd::usize(13)], expected_inherited.y(), 1e-5f);
 
-    parent_state->parallax_depth = { 0.0f, 0.0f };
-    child_state->parallax_depth  = { -0.7f, -0.7f };
+    parent_state->parallax.depth = { 0.0f, 0.0f };
+    child_state->parallax.depth  = { -0.7f, -0.7f };
     mvp                          = capture_mvp();
     auto expected_frozen         = expected_translation({ 1982.0f, 1053.0f }, { 0.0f, 0.0f });
     EXPECT_NEAR(mvp[rstd::usize(12)], expected_frozen.x(), 1e-5f);
     EXPECT_NEAR(mvp[rstd::usize(13)], expected_frozen.y(), 1e-5f);
 
-    parent_state->parallax_depth  = { 0.321f, 0.321f };
-    child_state->parallax_depth   = { 0.321f, 0.321f };
+    parent_state->parallax.depth = { 0.321f, 0.321f };
+    child_state->parallax.depth  = { 0.321f, 0.321f };
     mvp                           = capture_mvp();
     auto expected_parent_authored = expected_translation({ 1982.0f, 1053.0f }, { 0.321f, 0.321f });
     EXPECT_NEAR(mvp[rstd::usize(12)], expected_parent_authored.x(), 1e-5f);
@@ -976,8 +976,8 @@ TEST(UniformSourceParallax, OrthographicOmittedDepthUsesImplicitParallax) {
 
     auto layer_state = Arc<owe::UniformNodeState>::make(layer.clone(), camera_resolver.clone());
     layer_state->object_id               = i32(1);
-    layer_state->parallax_depth          = { 0.0f, 0.0f };
-    layer_state->parallax_depth_authored = false;
+    layer_state->parallax.depth    = { 0.0f, 0.0f };
+    layer_state->parallax.authored = false;
     state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) }, layer_state.clone());
 
     owe::TransformUniformSource source(state.clone(), layer_state.clone());
@@ -1036,8 +1036,8 @@ TEST(UniformSourceParallax, UnregisteredContainerRootDoesNotPoisonChildren) {
 
     auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
     child_state->object_id               = i32(2);
-    child_state->parallax_depth          = { -1.12f, -1.36f };
-    child_state->parallax_depth_authored = true;
+    child_state->parallax.depth    = { -1.12f, -1.36f };
+    child_state->parallax.authored = true;
     state->SetNodeState({ .index = rstd::u32(2), .generation = rstd::u32(1) }, child_state.clone());
 
     owe::TransformUniformSource source(state.clone(), child_state.clone());
@@ -1102,13 +1102,13 @@ TEST(UniformSourceParallax, DisablePropagationBlocksInheritance) {
 
     auto parent_state = Arc<owe::UniformNodeState>::make(parent.clone(), camera_resolver.clone());
     parent_state->object_id                      = i32(1);
-    parent_state->parallax_depth                 = { -1.56f, -0.79f };
-    parent_state->parallax_depth_authored        = true;
+    parent_state->parallax.depth    = { -1.56f, -0.79f };
+    parent_state->parallax.authored = true;
     parent_state->propagate_parallax_to_children = false;
     auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
     child_state->object_id               = i32(2);
-    child_state->parallax_depth          = { 0.0f, 0.0f };
-    child_state->parallax_depth_authored = false;
+    child_state->parallax.depth    = { 0.0f, 0.0f };
+    child_state->parallax.authored = false;
     state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) },
                         parent_state.clone());
     state->SetNodeState({ .index = rstd::u32(2), .generation = rstd::u32(1) }, child_state.clone());
@@ -1129,79 +1129,6 @@ TEST(UniformSourceParallax, DisablePropagationBlocksInheritance) {
     ASSERT_GT(mvp_blocked.size().to_primitive(), 13u);
     EXPECT_TRUE(std::abs(mvp_inherited[rstd::usize(12)] - mvp_blocked[rstd::usize(12)]) > 1e-5f ||
                 std::abs(mvp_inherited[rstd::usize(13)] - mvp_blocked[rstd::usize(13)]) > 1e-5f);
-}
-
-TEST(UniformSourceParallax, EffectModelReceivesParallaxShift) {
-    owe::Scene scene;
-    scene.SetOrtho({ i32(3840), i32(2160) });
-
-    auto camera_node = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1920.0f, 1080.0f, 0.0f },
-                                                 Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
-                                                 Eigen::Vector3f::Zero());
-    auto camera =
-        Arc<owe::SceneCamera>::make(owe::SceneCamera::MakeOrthographic(3840, 2160, -1.0, 1.0));
-    camera->AttatchNode(camera_node.as_ptr());
-    scene.RegisterCamera(String::make("default"_str), camera.clone());
-    ASSERT_TRUE(scene.SetActiveCamera("default"_str));
-
-    auto parent = Arc<owe::SceneNode>::make(Eigen::Vector3f { 1982.0f, 1053.0f, 0.0f },
-                                            Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
-                                            Eigen::Vector3f::Zero());
-    auto child  = Arc<owe::SceneNode>::make(Eigen::Vector3f { -76.0f, -3.0f, 0.0f },
-                                            Eigen::Vector3f { 1.0f, 1.0f, 1.0f },
-                                            Eigen::Vector3f::Zero());
-    auto effect = Arc<owe::SceneNode>::make();
-    auto mesh   = std::make_shared<owe::SceneMesh>();
-    mesh->AddMaterial(owe::SceneMaterial {});
-    owe::SceneMesh::Submesh submesh;
-    submesh.material_slot = u32();
-    mesh->Submeshes().push_back(std::move(submesh));
-    child->AddMesh(mesh);
-    parent->AppendChild(child.clone());
-    scene.RootMut()->AppendChild(parent.clone());
-    scene.RebuildResourceIndex();
-    effect->SetParentAnchor(child.as_ptr());
-
-    auto state = Arc<owe::UniformSceneState>::make(Arc<owe::AudioResponseDemand>::make());
-    state->SetLayerParallaxPolicy(true, true);
-    state->CameraParallax() = { true, 0.03f, 0.0f, 0.36f };
-    state->SetOrtho(3840.0f, 2160.0f);
-    state->SetPointerInput(0.0, 1.0);
-    state->Advance(owe::SceneFrame {});
-
-    auto camera_resolver = Arc<owe::UniformCameraResolver>::make(camera.clone());
-    camera_resolver->Add(String::make("default"_str), camera.clone());
-
-    auto parent_state = Arc<owe::UniformNodeState>::make(parent.clone(), camera_resolver.clone());
-    parent_state->object_id               = i32(1);
-    parent_state->parallax_depth          = { -1.56f, -0.79f };
-    parent_state->parallax_depth_authored = true;
-    auto child_state = Arc<owe::UniformNodeState>::make(child.clone(), camera_resolver.clone());
-    child_state->object_id               = i32(2);
-    child_state->parallax_depth          = { 1.0f, 1.0f };
-    child_state->parallax_depth_authored = false;
-    auto effect_state = Arc<owe::UniformNodeState>::make(effect.clone(), camera_resolver.clone());
-    effect_state->object_id               = i32(2);
-    effect_state->parallax_depth          = { 1.0f, 1.0f };
-    effect_state->parallax_depth_authored = false;
-    effect_state->effect_projection_node  = Some(child.clone());
-    effect_state->effect_projection_size  = { 3840.0f, 2160.0f };
-    state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) },
-                        parent_state.clone());
-    state->SetNodeState({ .index = rstd::u32(2), .generation = rstd::u32(1) }, child_state.clone());
-    state->SetNodeState({ .index = rstd::u32(3), .generation = rstd::u32(1) },
-                        effect_state.clone());
-
-    owe::TransformUniformSource source(state.clone(), effect_state.clone());
-    auto effect_enabled =
-        scene_test::Capture(scene.Runtime().Frame(), source, owe::TransformUniformOutput::EffectModel);
-    state->CameraParallax().enable = false;
-    auto effect_disabled =
-        scene_test::Capture(scene.Runtime().Frame(), source, owe::TransformUniformOutput::EffectModel);
-    ASSERT_GT(effect_enabled.size().to_primitive(), 13u);
-    ASSERT_GT(effect_disabled.size().to_primitive(), 13u);
-    EXPECT_TRUE(std::abs(effect_enabled[rstd::usize(12)] - effect_disabled[rstd::usize(12)]) > 1e-4f ||
-                std::abs(effect_enabled[rstd::usize(13)] - effect_disabled[rstd::usize(13)]) > 1e-4f);
 }
 
 TEST(UniformSourceParallax, PerspectiveWithoutAuthoredParallaxDepthSkipsShift) {
@@ -1240,8 +1167,8 @@ TEST(UniformSourceParallax, PerspectiveWithoutAuthoredParallaxDepthSkipsShift) {
 
     auto layer_state = Arc<owe::UniformNodeState>::make(layer.clone(), camera_resolver.clone());
     layer_state->object_id               = i32(31);
-    layer_state->parallax_depth          = { 0.0f, 0.0f };
-    layer_state->parallax_depth_authored = false;
+    layer_state->parallax.depth    = { 0.0f, 0.0f };
+    layer_state->parallax.authored = false;
     state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) }, layer_state.clone());
 
     owe::TransformUniformSource source(state.clone(), layer_state.clone());
@@ -1293,8 +1220,8 @@ TEST(UniformSourceParallax, PerspectiveWithAuthoredParallaxDepthAppliesShift) {
 
     auto layer_state = Arc<owe::UniformNodeState>::make(layer.clone(), camera_resolver.clone());
     layer_state->object_id               = i32(1);
-    layer_state->parallax_depth          = { 1.0f, 1.0f };
-    layer_state->parallax_depth_authored = true;
+    layer_state->parallax.depth    = { 1.0f, 1.0f };
+    layer_state->parallax.authored = true;
     state->SetNodeState({ .index = rstd::u32(1), .generation = rstd::u32(1) }, layer_state.clone());
 
     owe::TransformUniformSource source(state.clone(), layer_state.clone());

--- a/tests/tests/script-runtime/script_runtime_tests.cpp
+++ b/tests/tests/script-runtime/script_runtime_tests.cpp
@@ -659,9 +659,12 @@ TEST(ScriptNodeSoftMutation, RuntimeLayersKeepIndependentPendingParallaxDepth) {
     auto first  = Arc<owe::SceneNode>::make();
     auto writer = Arc<owe::SceneNode>::make();
     auto second = Arc<owe::SceneNode>::make();
-    state->RegisterNodeParallaxContract(*first, i32(-1), { 1.0f, 1.0f }, true);
-    state->RegisterNodeParallaxContract(*writer, i32(-1), { 1.0f, 1.0f }, true);
-    state->RegisterNodeParallaxContract(*second, i32(-2), { 1.0f, 1.0f }, true);
+    state->RegisterNodeParallaxContract(
+        *first, i32(-1), owe::wpscene::ParallaxDepthBinding { { 1.0f, 1.0f }, true });
+    state->RegisterNodeParallaxContract(
+        *writer, i32(-1), owe::wpscene::ParallaxDepthBinding { { 1.0f, 1.0f }, true });
+    state->RegisterNodeParallaxContract(
+        *second, i32(-2), owe::wpscene::ParallaxDepthBinding { { 1.0f, 1.0f }, true });
     EXPECT_TRUE(state->SetNodeParallaxDepth(*first, { 0.0f, 0.0f }));
 
     auto first_depth  = state->NodeParallaxDepth(*first);
@@ -683,8 +686,8 @@ TEST(ScriptNodeSoftMutation, RuntimeLayersKeepIndependentPendingParallaxDepth) {
     auto first_state       = Arc<owe::UniformNodeState>::make(first.clone(), cameras.clone());
     first_state->object_id = i32(-1);
     state->SetNodeState({ .index = u32(1), .generation = u32(1) }, first_state.clone());
-    EXPECT_FLOAT_EQ(first_state->parallax_depth[usize()], 0.0f);
-    EXPECT_FLOAT_EQ(first_state->parallax_depth[usize(1)], 0.0f);
+    EXPECT_FLOAT_EQ(first_state->parallax.depth[0], 0.0f);
+    EXPECT_FLOAT_EQ(first_state->parallax.depth[1], 0.0f);
 }
 
 TEST(ScriptNodeSoftMutation, ImageAlignmentBindingClonesForDynamicLayer) {

--- a/tests/tests/script-runtime/script_runtime_tests.cpp
+++ b/tests/tests/script-runtime/script_runtime_tests.cpp
@@ -659,9 +659,9 @@ TEST(ScriptNodeSoftMutation, RuntimeLayersKeepIndependentPendingParallaxDepth) {
     auto first  = Arc<owe::SceneNode>::make();
     auto writer = Arc<owe::SceneNode>::make();
     auto second = Arc<owe::SceneNode>::make();
-    state->RegisterNodeParallaxContract(*first, i32(-1), { 1.0f, 1.0f });
-    state->RegisterNodeParallaxContract(*writer, i32(-1), { 1.0f, 1.0f });
-    state->RegisterNodeParallaxContract(*second, i32(-2), { 1.0f, 1.0f });
+    state->RegisterNodeParallaxContract(*first, i32(-1), { 1.0f, 1.0f }, true);
+    state->RegisterNodeParallaxContract(*writer, i32(-1), { 1.0f, 1.0f }, true);
+    state->RegisterNodeParallaxContract(*second, i32(-2), { 1.0f, 1.0f }, true);
     EXPECT_TRUE(state->SetNodeParallaxDepth(*first, { 0.0f, 0.0f }));
 
     auto first_depth  = state->NodeParallaxDepth(*first);


### PR DESCRIPTION
## Summary

- Fix layer parallax in perspective scenes when `parallaxDepth` is omitted: layers were treated as depth `{1,1}`, causing large shifts (e.g. black screen in DELTARUNE). Omitted depth is now stored as zero and layer parallax is gated off unless the scene is orthographic or at least one object has an explicit `parallaxDepth`.
- Orthographic scenes still resolve omitted depth to implicit `{1,1}` at runtime, preserving 2D wallpaper parallax.
- Track authored vs omitted depth through inheritance (`disablepropagation`, nearest authored ancestor) and register parallax contracts only for authored depths.
- Consolidate into `ParallaxDepthBinding` with `ApplyParallaxUniformConfig` and `SceneObjectParallaxAuthored` so parse, uniform wiring, and `ComputeParallaxOffset` share one code path without changing the above behavior.

Reported by ViviNoSmol.

## Commits

1. `scene: fix 3D parallax when parallaxDepth is omitted` — behavioral fix and test coverage
2. `scene: consolidate parallax depth into ParallaxDepthBinding` — maintainability refactor on top of the fix